### PR TITLE
Added ADCAbsMean to ADCMonitor

### DIFF
--- a/STM32/DC/Core/Src/main.c
+++ b/STM32/DC/Core/Src/main.c
@@ -157,7 +157,7 @@ static double meanCurrent(const int16_t *pData, uint16_t channel)
     return current_scalar * ADCMean(pData, channel) + current_bias;
 }
 
-void printResult(const int16_t *pBuffer, int noOfChannels, int noOfSamples)
+void printResult(int16_t *pBuffer, int noOfChannels, int noOfSamples)
 {
     if (!isComPortOpen)
     {

--- a/STM32/Libraries/ADCMonitor/Inc/ADCMonitor.h
+++ b/STM32/Libraries/ADCMonitor/Inc/ADCMonitor.h
@@ -15,7 +15,7 @@ extern "C" {
  *                               CH0{sM}, CH2{sM},,,, CHN{SN} ], N,M =[0:inf]
  * SInce this modules does not has a fixed format the buffer is a one dimensional array and
  * each sample is fetched using pData[SampleNo * noOfChannls + channelNumber] */
-typedef void (*ADCCallBack)(const int16_t *pBuffer, int noOfChannels, int noOfSamples);
+typedef void (*ADCCallBack)(int16_t *pBuffer, int noOfChannels, int noOfSamples);
 
 // ADC Monitor initialisation function. MUST be called before call to any other function
 // Must only be called once.
@@ -28,6 +28,7 @@ void ADCMonitorLoop(ADCCallBack cb);
 // Standard helper function where noOfChannles/NoOfSamples is
 // used from ADCMonitorInit. Can be used for skeleton locally.
 double ADCMean(const int16_t *pData, uint16_t channel);
+double ADCAbsMean(const int16_t *pData, uint16_t channel);
 double ADCrms(const int16_t *pData, uint16_t channel);
 uint16_t ADCmax(const int16_t *pData, uint16_t channel);
 

--- a/STM32/Libraries/ADCMonitor/Src/ADCmonitor.c
+++ b/STM32/Libraries/ADCMonitor/Src/ADCmonitor.c
@@ -46,7 +46,7 @@ void ADCMonitorLoop(ADCCallBack callback)
     if (ADCMonitorData.activeBuffer != lastBuffer)
     {
         lastBuffer = ADCMonitorData.activeBuffer;
-        const int16_t *pData = (ADCMonitorData.activeBuffer == First)
+        int16_t *pData = (ADCMonitorData.activeBuffer == First)
                 ? ADCMonitorData.pData : &ADCMonitorData.pData[ADCMonitorData.length / 2];
         callback(pData, ADCMonitorData.noOfChannels, ADCMonitorData.noOfSamples);
     }
@@ -84,6 +84,24 @@ double ADCMean(const int16_t *pData, uint16_t channel)
     for (uint32_t sampleId = 0; sampleId < ADCMonitorData.noOfSamples; sampleId++)
     {
         sum += pData[sampleId*ADCMonitorData.noOfChannels + channel];
+    }
+
+    return (sum / ADCMonitorData.noOfSamples);
+}
+
+double ADCAbsMean(const int16_t *pData, uint16_t channel)
+{
+    if (ADCMonitorData.activeBuffer == NotAvailable ||
+        pData == NULL ||
+        channel >= ADCMonitorData.noOfChannels)
+    {
+        return 0;
+    }
+
+    uint64_t sum = 0;
+    for (uint32_t sampleId = 0; sampleId < ADCMonitorData.noOfSamples; sampleId++)
+    {
+        sum += abs(pData[sampleId*ADCMonitorData.noOfChannels + channel]);
     }
 
     return (sum / ADCMonitorData.noOfSamples);


### PR DESCRIPTION
Also changed interface for callback function in DC module.
The ADCAbsMean can be used to calculate the total 'weight' of a signal.