### PR TITLE
Use circualar buffer when sending via USB cdc

### DIFF
--- a/STM32/AC/USB_DEVICE/App/usbd_cdc_if.h
+++ b/STM32/AC/USB_DEVICE/App/usbd_cdc_if.h
@@ -94,7 +94,6 @@ bool isComPortOpen;
 extern USBD_CDC_ItfTypeDef USBD_Interface_fops_FS;
 
 /* USER CODE BEGIN EXPORTED_VARIABLES */
-extern uint8_t serialBuffer[64];
 cbuf_handle_t cbuf;
 /* USER CODE END EXPORTED_VARIABLES */
 
@@ -110,7 +109,10 @@ cbuf_handle_t cbuf;
 uint8_t CDC_Transmit_FS(uint8_t* Buf, uint16_t Len);
 
 /* USER CODE BEGIN EXPORTED_FUNCTIONS */
+
+// TODO: remove this, main should not know about internal circular buffers.
 void circularBufferInit();
+
 /* USER CODE END EXPORTED_FUNCTIONS */
 
 /**

--- a/STM32/Libraries/USBprint/Src/USBprint.c
+++ b/STM32/Libraries/USBprint/Src/USBprint.c
@@ -79,7 +79,5 @@ int USBnprintf(const char * format, ... )
     va_end (args);
 
     CDC_Transmit_FS((uint8_t*)buffer, len);
-    HAL_Delay(2);
-
     return len;
 }


### PR DESCRIPTION
This will make the HAL delay obsoletewhen sending via USB cdc