### PR TITLE
Use <LF> for C and h files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 *.ioc binary
+*.c text=lf
+*.h text=lf
 


### PR DESCRIPTION
STM IDE and some editors changes line endings when reading files
and automaticly changes line endings to \<CR\>\<LF\>.

This 'feature' makes it close to impossible to perform review of code.
This change attributes settings forces the lineendigs to \<LF\> durring
commit.

Doc: https://git-scm.com/docs/gitattributes