### PR TITLE
Added Git info version file version.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Debug
 .settings
 *.launch
 *.mxproject
+githash.h

--- a/STM32/AC/makefile.init
+++ b/STM32/AC/makefile.init
@@ -1,0 +1,31 @@
+# git commit version and date
+
+GIT_VERSION := $(shell git --no-pager describe --tags --always --dirty)
+GIT_DATE := $(firstword $(shell git --no-pager show --date=short --format="%ad" --name-only))
+GIT_SHA := $(shell git rev-parse HEAD)
+
+mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
+mkfile_dir := $(dir $(mkfile_path))
+
+TARGET := ${mkfile_dir}/Core/Inc/githash.h
+
+all: $(TARGET)
+.PHONY: force
+
+define git_info
+// Auto generated file from makefile.init, do not edit!
+
+#ifndef GIT_HASH_H
+#define GIT_HASH_H
+
+#define GIT_SHA \"$(GIT_SHA)\"
+#define GIT_DATE  \"$(GIT_DATE)\"
+#define GIT_VERSION \"$(GIT_VERSION)\"
+
+#endif // GIT_HASH_H
+endef
+
+.ONESHELL:
+$(TARGET): force
+	@echo "$(git_info)" > $@
+


### PR DESCRIPTION
The output header file will contain this info:
// Auto generated file from makefile.init, do not edit!

#ifndef GIT_HASH_H
#define GIT_HASH_H

#define GIT_SHA "6c2c8e9f33540d2192643d50138bc48976bf4f6d"
#define GIT_DATE  "2021-09-23"
#define GIT_VERSION "6c2c8e9"

#endif // GIT_HASH_H

FIle makefile.init is called from Debug/makefile and the Core/Inc/githash.h is generated. The githash.h file is not included in repository.