### PR TITLE
Added new directory for utility functions

### DIFF
--- a/STM32/AC/.cproject
+++ b/STM32/AC/.cproject
@@ -56,6 +56,7 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/AC/InputValidation/Inc}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/AC/PinActuation/Inc}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/AC/Libraries/ADCMonitor/Inc}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/AC/Libraries/Util/Inc}&quot;"/>
 								</option>
 								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c.1215116355" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c"/>
 							</tool>
@@ -93,6 +94,7 @@
 						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="Middlewares"/>
 						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="PinActuation"/>
 						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="USB_DEVICE"/>
+						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="Util"/>
 					</sourceEntries>
 				</configuration>
 			</storageModule>

--- a/STM32/AC/.project
+++ b/STM32/AC/.project
@@ -35,5 +35,10 @@
 			<type>2</type>
 			<locationURI>PARENT-1-PROJECT_LOC/Libraries</locationURI>
 		</link>
+		<link>
+			<name>Util</name>
+			<type>2</type>
+			<location>/home/agp/work/CA_Embedded/STM32/Libraries/Util</location>
+		</link>
 	</linkedResources>
 </projectDescription>

--- a/STM32/AC/Core/Src/main.c
+++ b/STM32/AC/Core/Src/main.c
@@ -30,6 +30,7 @@
 #include "inputValidation.h"
 #include "pinActuation.h"
 #include "ADCMonitor.h"
+#include "systemInfo.h"
 
 /* USER CODE END Includes */
 
@@ -44,11 +45,6 @@
 #define ADC_CHANNELS	5
 #define ADC_CHANNEL_BUF_SIZE	400
 
-//-------------F4xx UID--------------------
-#define ID1 (*(unsigned long *)0x1FFF7A10)
-#define ID2 (*(unsigned long *)0x1FFF7A14)
-#define ID3 (*(unsigned long *)0x1FFF7A18)
-
 // ***** PRODUCT INFO *****
 /*
  * Versions:
@@ -58,11 +54,9 @@
  * 1.3 Add print heatsink temperature.
  */
 
-char softwareVersion[] = "1.4";
-char productType[] = "AC Board";
-char mcuFamily[] = "STM32F401";
-char pcbVersion[] = "V5.6";
-char compileDate[] = __DATE__ " " __TIME__;
+#define ProductType "AC Board"
+#define McuFamily   "STM32F401"
+#define PCBVersion  "V5.6"
 
 /* USER CODE END PD */
 
@@ -118,15 +112,7 @@ static void MX_TIM2_Init(void);
 
 void printHeader()
 {
-    char buf[250] = { 0 };
-    int len = 0;
-    len  = snprintf(&buf[len], sizeof(buf) - len, "Serial Number: %lX%lX%lX\r\n", ID1, ID2, ID3);
-    len += snprintf(&buf[len], sizeof(buf) - len, "Product Type: %s\r\n", productType);
-    len += snprintf(&buf[len], sizeof(buf) - len, "Software Version: %s\r\n", softwareVersion);
-    len += snprintf(&buf[len], sizeof(buf) - len, "Compile Date: %s\r\n", compileDate);
-    len += snprintf(&buf[len], sizeof(buf) - len, "MCU Family: %s\r\n", mcuFamily);
-    len += snprintf(&buf[len], sizeof(buf) - len, "PCB Version: %s", pcbVersion);
-    USBnprintf(buf);
+    USBnprintf(systemInfo(ProductType, McuFamily, PCBVersion));
 }
 
 double ADCtoCurrent(double adc_val) {

--- a/STM32/Libraries/Util/Inc/systemInfo.h
+++ b/STM32/Libraries/Util/Inc/systemInfo.h
@@ -1,0 +1,8 @@
+#ifndef SYSTEM_INFO_H
+#define SYSTEM_INFO_H
+
+/* Generic info about PCB and git build system/data.
+ * @return info about system in null terminated string. */
+const char* systemInfo(const char* productType, const char* mcuFamily, const char* pcbVersion);
+
+#endif // SYSTEM_INFO_H

--- a/STM32/Libraries/Util/Src/systeminfo.c
+++ b/STM32/Libraries/Util/Src/systeminfo.c
@@ -1,0 +1,30 @@
+/*
+ * Generic functions used the the STM system
+ */
+
+#include <stdio.h>
+
+#include "stm32f4xx_hal.h"
+#include "systemInfo.h"
+#include "githash.h"
+
+// F4xx UID
+#define ID1 *((unsigned long *) (UID_BASE))
+#define ID2 *((unsigned long *) (UID_BASE + 4U))
+#define ID3 *((unsigned long *) (UID_BASE + 8U))
+
+const char* systemInfo(const char* productType, const char* mcuFamily, const char* pcbVersion)
+{
+    static char buf[400] = { 0 };
+    int len = 0;
+
+    len  = snprintf(&buf[len], sizeof(buf) - len, "Serial Number: %lX%lX%lX\r\n", ID1, ID2, ID3);
+    len += snprintf(&buf[len], sizeof(buf) - len, "Product Type: %s\r\n", productType);
+    len += snprintf(&buf[len], sizeof(buf) - len, "MCU Family: %s\r\n", mcuFamily);
+    len += snprintf(&buf[len], sizeof(buf) - len, "PCB Version: %s\r\n", pcbVersion);
+    len += snprintf(&buf[len], sizeof(buf) - len, "Software Version: %s\r\n", GIT_VERSION);
+    len += snprintf(&buf[len], sizeof(buf) - len, "Compile Date: %s\r\n", GIT_DATE);
+    len += snprintf(&buf[len], sizeof(buf) - len, "Git SHA %s", GIT_SHA);
+
+    return buf;
+}


### PR DESCRIPTION
First utility function is a function to return a generic string that contains various generic info about hardware and software.
This function could/should replace most printheader() functions.

Tested on a AC board and output is:
Serial Number: 59001B3034510736383838
Product Type: AC Board
MCU Family: STM32F401
PCB Version: V5.6
Software Version: 42637e1
Compile Date: 2021-09-24
Git SHA 42637e126ee6e4aebae7ecfa8b54d1f33d9df2cd
