### PR TITLE
AC/DC board: Max current draw and max temp detection and handling

### DIFF
--- a/STM32/AC/Core/Src/main.c
+++ b/STM32/AC/Core/Src/main.c
@@ -117,12 +117,16 @@ void printHeader()
     USBnprintf(systemInfo(ProductType, McuFamily, PCBVersion));
 }
 
+void shutOffAndReport(){
+	allOff();
+	USBnprintf("warning: max temp exceeded.");
+}
+
 double ADCtoCurrent(double adc_val) {
 
 	double currentChannel = current_scalar * adc_val + current_bias;
 	if (currentChannel > MAX_CURRENT_DRAW){
-		allOff();
-		USBnprintf("warning: max current exceeded.");
+		shutOffAndReport();
 	}
 	return currentChannel;
 }
@@ -130,8 +134,7 @@ double ADCtoCurrent(double adc_val) {
 double ADCtoTemperature(double adc_val) {
 	double board_temp = temp_scalar * adc_val;
 	if (board_temp > MAX_BOARD_TEMP){
-		allOff();
-		USBnprintf("warning: max current exceeded.");
+		shutOffAndReport();
 	}
 	return board_temp;
 }

--- a/STM32/AC/Core/Src/main.c
+++ b/STM32/AC/Core/Src/main.c
@@ -117,16 +117,21 @@ void printHeader()
     USBnprintf(systemInfo(ProductType, McuFamily, PCBVersion));
 }
 
-void shutOffAndReport(){
+void shutOffAndReport(bool isCurrentExceeded){
 	allOff();
-	USBnprintf("warning: max temp exceeded.");
+	if (isCurrentExceeded){
+		USBnprintf("warning: max current draw exceeded.");
+	} else {
+		USBnprintf("warning: max temp exceeded.");
+	}
 }
 
 double ADCtoCurrent(double adc_val) {
 
 	double currentChannel = current_scalar * adc_val + current_bias;
 	if (currentChannel > MAX_CURRENT_DRAW){
-		shutOffAndReport();
+		bool isCurrentExceeded = true;
+		shutOffAndReport(isCurrentExceeded);
 	}
 	return currentChannel;
 }
@@ -134,7 +139,8 @@ double ADCtoCurrent(double adc_val) {
 double ADCtoTemperature(double adc_val) {
 	double board_temp = temp_scalar * adc_val;
 	if (board_temp > MAX_BOARD_TEMP){
-		shutOffAndReport();
+		bool isCurrentExceeded = false;
+		shutOffAndReport(isCurrentExceeded);
 	}
 	return board_temp;
 }

--- a/STM32/AC/Core/Src/main.c
+++ b/STM32/AC/Core/Src/main.c
@@ -45,6 +45,8 @@
 #define ADC_CHANNELS	5
 #define ADC_CHANNEL_BUF_SIZE	400
 
+#define MAX_CURRENT_DRAW 9
+#define MAX_BOARD_TEMP 50
 // ***** PRODUCT INFO *****
 /*
  * Versions:
@@ -116,11 +118,22 @@ void printHeader()
 }
 
 double ADCtoCurrent(double adc_val) {
-	return current_scalar * adc_val + current_bias;
+
+	double currentChannel = current_scalar * adc_val + current_bias;
+	if (currentChannel > MAX_CURRENT_DRAW){
+		allOff();
+		USBnprintf("warning: max current exceeded.");
+	}
+	return currentChannel;
 }
 
 double ADCtoTemperature(double adc_val) {
-	return temp_scalar * adc_val;
+	double board_temp = temp_scalar * adc_val;
+	if (board_temp > MAX_BOARD_TEMP){
+		allOff();
+		USBnprintf("warning: max current exceeded.");
+	}
+	return board_temp;
 }
 
 static void printCurrentArray(int16_t *pData, int noOfChannels, int noOfSamples)

--- a/STM32/DC/Core/Inc/main.h
+++ b/STM32/DC/Core/Inc/main.h
@@ -29,7 +29,7 @@ extern "C" {
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f4xx_hal.h"
-
+#include <stdbool.h>
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
 
@@ -56,7 +56,9 @@ void HAL_TIM_MspPostInit(TIM_HandleTypeDef *htim);
 void Error_Handler(void);
 
 /* USER CODE BEGIN EFP */
-
+void pinWrite(int pinNumber, bool turnOn);
+void allOff();
+void turnOffPin(int pinNumber);
 /* USER CODE END EFP */
 
 /* Private defines -----------------------------------------------------------*/

--- a/STM32/DC/Core/Src/main.c
+++ b/STM32/DC/Core/Src/main.c
@@ -153,12 +153,8 @@ void printHeader()
     USBnprintf(buf);
 }
 
-void shutChannelOffAndReport(uint16_t channel){
-	turnOffPin(channel);
-	USBnprintf("warning: max current exceeded.");
-}
 
-void shutAllOffAndReport(){
+void shutOffAndReport(){
 	allOff();
 	USBnprintf("warning: max temp exceeded.");
 }
@@ -169,7 +165,7 @@ static double meanCurrent(const int16_t *pData, uint16_t channel)
 
     // If component draws more current than max allowed then operation is shut off
     if (meanCurrent > MAX_CURRENT_DRAW){
-    	shutChannelOffAndReport(channel);
+    	shutOffAndReport();
     }
     return meanCurrent;
 }
@@ -187,7 +183,7 @@ void printResult(int16_t *pBuffer, int noOfChannels, int noOfSamples)
     const double temp = si7051Temp(&hi2c1);
     // If board temp exceeds 50C shut down operation
     if (temp>MAX_BOARD_TEMP){
-    	shutAllOffAndReport();
+    	shutOffAndReport();
     }
 
     USBnprintf("%.2f, %.2f, %.2f, %.2f, %.2f, %.2f, %d",

--- a/STM32/DC/Core/Src/main.c
+++ b/STM32/DC/Core/Src/main.c
@@ -154,9 +154,13 @@ void printHeader()
 }
 
 
-void shutOffAndReport(){
+void shutOffAndReport(bool isCurrentExceeded){
 	allOff();
-	USBnprintf("warning: max temp exceeded.");
+	if (isCurrentExceeded){
+		USBnprintf("warning: max current draw exceeded.");
+	} else {
+		USBnprintf("warning: max temp exceeded.");
+	}
 }
 
 static double meanCurrent(const int16_t *pData, uint16_t channel)
@@ -165,7 +169,8 @@ static double meanCurrent(const int16_t *pData, uint16_t channel)
 
     // If component draws more current than max allowed then operation is shut off
     if (meanCurrent > MAX_CURRENT_DRAW){
-    	shutOffAndReport();
+    	bool isCurrentExceeded = true;
+    	shutOffAndReport(isCurrentExceeded);
     }
     return meanCurrent;
 }
@@ -183,7 +188,8 @@ void printResult(int16_t *pBuffer, int noOfChannels, int noOfSamples)
     const double temp = si7051Temp(&hi2c1);
     // If board temp exceeds 50C shut down operation
     if (temp>MAX_BOARD_TEMP){
-    	shutOffAndReport();
+    	bool isCurrentExceeded = false;
+    	shutOffAndReport(isCurrentExceeded);
     }
 
     USBnprintf("%.2f, %.2f, %.2f, %.2f, %.2f, %.2f, %d",


### PR DESCRIPTION
The AC board is not designed to withstand continuous current draw above 9A. For the DC it is 2A. If a current draw on either of the boards exceed those limits the boards will turn off all pins and give a warning. Warning format:

"warning: max current draw exceeded."

Likewise for temperature the boards are not designed to withstand high temperature for longer periods of time. If the board temperature exceeds 50C then all pins are shut off and a warning is given.

"warning: max temp exceeded."


