### PR TITLE
Use common circualar buffer when sending via USB cdc

### DIFF
--- a/STM32/AC/.cproject
+++ b/STM32/AC/.cproject
@@ -38,6 +38,7 @@
 									<listOptionValue builtIn="false" value="DEBUG"/>
 									<listOptionValue builtIn="false" value="USE_HAL_DRIVER"/>
 									<listOptionValue builtIn="false" value="STM32F401xC"/>
+									<listOptionValue builtIn="false" value="USE_COMMON_USB_CDC"/>
 								</option>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.includepaths.181471499" name="Include paths (-I)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.includepaths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="../USB_DEVICE/Target"/>

--- a/STM32/AC/USB_DEVICE/App/usb_device.c
+++ b/STM32/AC/USB_DEVICE/App/usb_device.c
@@ -28,7 +28,7 @@
 #include "usbd_cdc_if.h"
 
 /* USER CODE BEGIN Includes */
-
+#include "usb_cdc_fops.h" // Replace the USBD_Interface_fops_FS defined in usbd_cdc_if.c.
 /* USER CODE END Includes */
 
 /* USER CODE BEGIN PV */
@@ -65,6 +65,7 @@ USBD_HandleTypeDef hUsbDeviceFS;
 void MX_USB_DEVICE_Init(void)
 {
   /* USER CODE BEGIN USB_DEVICE_Init_PreTreatment */
+    USBD_Interface_fops_FS = usb_cdc_fops;
 
   /* USER CODE END USB_DEVICE_Init_PreTreatment */
 

--- a/STM32/AC/USB_DEVICE/App/usbd_cdc_if.c
+++ b/STM32/AC/USB_DEVICE/App/usbd_cdc_if.c
@@ -23,7 +23,6 @@
 #include "usbd_cdc_if.h"
 
 /* USER CODE BEGIN INCLUDE */
-#include "circular_buffer.h"
 #include <stdbool.h>
 /* USER CODE END INCLUDE */
 
@@ -99,10 +98,8 @@ USBD_CDC_LineCodingTypeDef LineCoding = {
 uint8_t UserRxBufferFS[APP_RX_DATA_SIZE];
 
 /** Data to send over USB CDC are stored in this buffer   */
-uint8_t UserTxBufferFS[APP_TX_DATA_SIZE];
 
 /* USER CODE BEGIN PRIVATE_VARIABLES */
-uint8_t circularBuffer[CIRCULAR_BUFFER_SIZE * sizeof(uint8_t)]; //malloc(CIRCULAR_BUFFER_SIZE * sizeof(uint8_t));
 /* USER CODE END PRIVATE_VARIABLES */
 
 /**
@@ -117,7 +114,6 @@ uint8_t circularBuffer[CIRCULAR_BUFFER_SIZE * sizeof(uint8_t)]; //malloc(CIRCULA
 extern USBD_HandleTypeDef hUsbDeviceFS;
 
 /* USER CODE BEGIN EXPORTED_VARIABLES */
-bool isComPortOpen = false;
 /* USER CODE END EXPORTED_VARIABLES */
 
 /**
@@ -136,23 +132,6 @@ static int8_t CDC_Receive_FS(uint8_t* pbuf, uint32_t *Len);
 static int8_t CDC_TransmitCplt_FS(uint8_t *pbuf, uint32_t *Len, uint8_t epnum);
 
 /* USER CODE BEGIN PRIVATE_FUNCTIONS_DECLARATION */
-
-void circularBufferInit(){
-	cbuf = circular_buf_init(circularBuffer, CIRCULAR_BUFFER_SIZE);
-}
-
-/*
-void updateSerialBuffer(cbuf_handle_t cbuf){
-	int i = 0;
-	uint8_t tmpBuf[CIRCULAR_BUFFER_SIZE];
-	while(!circular_buf_empty(cbuf)){
-		uint8_t data;
-		circular_buf_get(cbuf, &data);
-		tmpBuf[i] = data;
-		i++;
-	}
-	memcpy(serialBuffer, tmpBuf, strlen(tmpBuf));
-}*/
 /* USER CODE END PRIVATE_FUNCTIONS_DECLARATION */
 
 /**
@@ -176,11 +155,8 @@ USBD_CDC_ItfTypeDef USBD_Interface_fops_FS =
 static int8_t CDC_Init_FS(void)
 {
   /* USER CODE BEGIN 3 */
-  /* Set Application Buffers */
-  USBD_CDC_SetTxBuffer(&hUsbDeviceFS, UserTxBufferFS, 0);
-  USBD_CDC_SetRxBuffer(&hUsbDeviceFS, UserRxBufferFS);
-  return (USBD_OK);
   /* USER CODE END 3 */
+    return (USBD_OK);
 }
 
 /**
@@ -204,83 +180,8 @@ static int8_t CDC_DeInit_FS(void)
 static int8_t CDC_Control_FS(uint8_t cmd, uint8_t* pbuf, uint16_t length)
 {
   /* USER CODE BEGIN 5 */
-  switch(cmd)
-  {
-    case CDC_SEND_ENCAPSULATED_COMMAND:
-
-    break;
-
-    case CDC_GET_ENCAPSULATED_RESPONSE:
-
-    break;
-
-    case CDC_SET_COMM_FEATURE:
-
-    break;
-
-    case CDC_GET_COMM_FEATURE:
-
-    break;
-
-    case CDC_CLEAR_COMM_FEATURE:
-
-    break;
-
-  /*******************************************************************************/
-  /* Line Coding Structure                                                       */
-  /*-----------------------------------------------------------------------------*/
-  /* Offset | Field       | Size | Value  | Description                          */
-  /* 0      | dwDTERate   |   4  | Number |Data terminal rate, in bits per second*/
-  /* 4      | bCharFormat |   1  | Number | Stop bits                            */
-  /*                                        0 - 1 Stop bit                       */
-  /*                                        1 - 1.5 Stop bits                    */
-  /*                                        2 - 2 Stop bits                      */
-  /* 5      | bParityType |  1   | Number | Parity                               */
-  /*                                        0 - None                             */
-  /*                                        1 - Odd                              */
-  /*                                        2 - Even                             */
-  /*                                        3 - Mark                             */
-  /*                                        4 - Space                            */
-  /* 6      | bDataBits  |   1   | Number Data bits (5, 6, 7, 8 or 16).          */
-  /*******************************************************************************/
-    case CDC_SET_LINE_CODING:
-    	LineCoding.bitrate = (uint32_t)(pbuf[0] | (pbuf[1] << 8) |\
-		(pbuf[2] << 16) | (pbuf[3] << 24));
-		LineCoding.format = pbuf[4];
-		LineCoding.paritytype = pbuf[5];
-		LineCoding.datatype = pbuf[6];
-    break;
-
-    case CDC_GET_LINE_CODING:
-    	pbuf[0] = (uint8_t)(LineCoding.bitrate);
-		pbuf[1] = (uint8_t)(LineCoding.bitrate >> 8);
-		pbuf[2] = (uint8_t)(LineCoding.bitrate >> 16);
-		pbuf[3] = (uint8_t)(LineCoding.bitrate >> 24);
-		pbuf[4] = LineCoding.format;
-		pbuf[5] = LineCoding.paritytype;
-		pbuf[6] = LineCoding.datatype;
-    break;
-
-    case CDC_SET_CONTROL_LINE_STATE:{
-          USBD_SetupReqTypedef * req = (USBD_SetupReqTypedef *)pbuf;
-          if((req->wValue &0x0001) != 0){
-        	  isComPortOpen = true;
-          } else {
-        	  isComPortOpen = false;
-          }
-    }
-    break;
-
-    case CDC_SEND_BREAK:
-
-    break;
-
-  default:
-    break;
-  }
-
-  return (USBD_OK);
   /* USER CODE END 5 */
+  return (USBD_OK);
 }
 
 /**
@@ -301,22 +202,8 @@ static int8_t CDC_Control_FS(uint8_t cmd, uint8_t* pbuf, uint16_t length)
 static int8_t CDC_Receive_FS(uint8_t* Buf, uint32_t *Len)
 {
   /* USER CODE BEGIN 6 */
-  USBD_CDC_SetRxBuffer(&hUsbDeviceFS, &Buf[0]);
-  USBD_CDC_ReceivePacket(&hUsbDeviceFS);
-
-  uint16_t len = (uint16_t)*Len;
-  // Update circular buffer with incoming values
-  for(uint8_t i = 0; i < len; i++){
-	  circular_buf_put(cbuf, Buf[i]);
-	  // Checking for '\r' is there for debugging purposes which is sent by putty and minicom.
-	  // In production only '\n' is sent. Therefore, there is no check for '\r\n' case.
-	  if (Buf[i]=='\n'||Buf[i]=='\r'){
-		  circular_buf_add_input(cbuf);
-	  }
-  }
-  memset(Buf, '\0', len);   // clear the Buf also
-  return (USBD_OK);
   /* USER CODE END 6 */
+  return (USBD_OK);
 }
 
 /**
@@ -334,12 +221,6 @@ uint8_t CDC_Transmit_FS(uint8_t* Buf, uint16_t Len)
 {
   uint8_t result = USBD_OK;
   /* USER CODE BEGIN 7 */
-  USBD_CDC_HandleTypeDef *hcdc = (USBD_CDC_HandleTypeDef*)hUsbDeviceFS.pClassData;
-  if (hcdc->TxState != 0){
-    return USBD_BUSY;
-  }
-  USBD_CDC_SetTxBuffer(&hUsbDeviceFS, Buf, Len);
-  result = USBD_CDC_TransmitPacket(&hUsbDeviceFS);
   /* USER CODE END 7 */
   return result;
 }
@@ -360,15 +241,11 @@ static int8_t CDC_TransmitCplt_FS(uint8_t *Buf, uint32_t *Len, uint8_t epnum)
 {
   uint8_t result = USBD_OK;
   /* USER CODE BEGIN 13 */
-  UNUSED(Buf);
-  UNUSED(Len);
-  UNUSED(epnum);
   /* USER CODE END 13 */
   return result;
 }
 
 /* USER CODE BEGIN PRIVATE_FUNCTIONS_IMPLEMENTATION */
-
 /* USER CODE END PRIVATE_FUNCTIONS_IMPLEMENTATION */
 
 /**

--- a/STM32/AC/USB_DEVICE/App/usbd_cdc_if.h
+++ b/STM32/AC/USB_DEVICE/App/usbd_cdc_if.h
@@ -31,7 +31,6 @@
 #include "usbd_cdc.h"
 
 /* USER CODE BEGIN INCLUDE */
-#include "circular_buffer.h"
 /* USER CODE END INCLUDE */
 
 /** @addtogroup STM32_USB_OTG_DEVICE_LIBRARY
@@ -65,7 +64,6 @@
   */
 
 /* USER CODE BEGIN EXPORTED_TYPES */
-bool isComPortOpen;
 /* USER CODE END EXPORTED_TYPES */
 
 /**
@@ -94,8 +92,6 @@ bool isComPortOpen;
 extern USBD_CDC_ItfTypeDef USBD_Interface_fops_FS;
 
 /* USER CODE BEGIN EXPORTED_VARIABLES */
-extern uint8_t serialBuffer[64];
-cbuf_handle_t cbuf;
 /* USER CODE END EXPORTED_VARIABLES */
 
 /**
@@ -110,7 +106,6 @@ cbuf_handle_t cbuf;
 uint8_t CDC_Transmit_FS(uint8_t* Buf, uint16_t Len);
 
 /* USER CODE BEGIN EXPORTED_FUNCTIONS */
-void circularBufferInit();
 /* USER CODE END EXPORTED_FUNCTIONS */
 
 /**

--- a/STM32/Libraries/USBprint/Inc/usb_cdc_fops.h
+++ b/STM32/Libraries/USBprint/Inc/usb_cdc_fops.h
@@ -1,0 +1,42 @@
+/*
+ * This file should replace the implementation in USB_DEVICE/App/usbd_cdc_if.
+ * The remaining handling USB initialization should be re-used (for now).
+ * What must be done in USB_DEVICE/App/usb_device.c is to overwrite the
+ * USBD_Interface_fops_FS with our own reader/write functions. Add this
+ * include file to USB_DEVICE/App/usb_device.c and add this line:
+ *
+ * USBD_Interface_fops_FS = usb_cdc_fops;
+ *
+ * in function void MX_USB_DEVICE_Init(void)
+ *
+ * The reason to do overwrite is that the usb cdc interface needs changes.
+ * Theses changes is required for _ALL_ boards since USB_DEVICE resides
+ * in the project directory and not as a library, so to prevent copy/paste
+ * this new usb_cdc_fops module has been introduced.
+ */
+#ifndef USB_CDC_FOPS_H
+#define USB_CDC_FOPS_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#include "usbd_cdc.h"
+#include "stdbool.h"
+
+extern USBD_CDC_ItfTypeDef usb_cdc_fops;
+
+#define CIRCULAR_BUFFER_SIZE 1028
+
+uint8_t usb_cdc_transmit(uint8_t* Buf, uint16_t len);
+// Note, it assumed that buf is of size CIRCULAR_BUFFER_SIZE
+void usb_cdc_rx(uint8_t* buf);
+void usb_cdc_rx_flush();
+
+bool isComPortOpen();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/STM32/Libraries/USBprint/Src/USBprint.c
+++ b/STM32/Libraries/USBprint/Src/USBprint.c
@@ -10,7 +10,11 @@
 #include "stdarg.h"
 #include "string.h"
 #include "stdio.h"
-#include "usbd_cdc_if.h"
+#ifdef USE_COMMON_USB_CDC
+    #include "usb_cdc_fops.h"
+#else
+    #include "usbd_cdc_if.h"
+#endif
 
 int USBnprintf(const char * format, ... )
 {
@@ -22,8 +26,12 @@ int USBnprintf(const char * format, ... )
     len += vsnprintf(&buffer[len], sizeof(buffer) - len, format, args);
     va_end (args);
 
+#ifdef USE_COMMON_USB_CDC
+    usb_cdc_transmit((uint8_t*)buffer, len);
+#else
     CDC_Transmit_FS((uint8_t*)buffer, len);
     HAL_Delay(2);
 
+#endif
     return len;
 }

--- a/STM32/Libraries/USBprint/Src/usb_cdc_fops.c
+++ b/STM32/Libraries/USBprint/Src/usb_cdc_fops.c
@@ -1,0 +1,275 @@
+/*
+ * TODO:
+ */
+
+#include "usb_cdc_fops.h"
+#include "circular_buffer.h"
+#include <stdbool.h>
+
+static int8_t CDC_Init_FS(void);
+static int8_t CDC_DeInit_FS(void);
+static int8_t CDC_Control_FS(uint8_t cmd, uint8_t* pbuf, uint16_t length);
+static int8_t CDC_Receive_FS(uint8_t* pbuf, uint32_t *Len);
+static int8_t CDC_TransmitCplt_FS(uint8_t *pbuf, uint32_t *Len, uint8_t epnum);
+
+extern USBD_HandleTypeDef hUsbDeviceFS;
+USBD_CDC_ItfTypeDef usb_cdc_fops =
+{
+        CDC_Init_FS,
+        CDC_DeInit_FS,
+        CDC_Control_FS,
+        CDC_Receive_FS,
+        CDC_TransmitCplt_FS
+};
+
+static USBD_CDC_LineCodingTypeDef LineCoding = {
+        115200, /* baud rate     */
+        0x00,   /* stop bits-1   */
+        0x00,   /* parity - none */
+        0x08    /* nb. of bits 8 */
+};
+
+// Internal data for rx/tx
+static struct
+{
+    struct {
+        cbuf_handle_t ctx;
+        uint8_t buf[CIRCULAR_BUFFER_SIZE];      // Upper layer buffer for user application
+        uint8_t irqBuf[CIRCULAR_BUFFER_SIZE];   // lower layer buffer for IRQ USB_CDC driver callback
+    } tx, rx;
+    bool isComPortOpen;
+} usb_cdc_if = { {0}, {0}, false };
+
+bool isComPortOpen() {
+    return usb_cdc_if.isComPortOpen;
+}
+
+/**
+  * @brief  Initializes the CDC media low layer over the FS USB IP
+  * @retval USBD_OK if all operations are OK else USBD_FAIL
+  */
+static int8_t CDC_Init_FS(void)
+{
+    // Setup TX Buffer
+    USBD_CDC_SetTxBuffer(&hUsbDeviceFS, usb_cdc_if.tx.irqBuf, 0);
+    usb_cdc_if.tx.ctx = circular_buf_init(usb_cdc_if.tx.buf, sizeof(usb_cdc_if.tx.buf));
+
+    // Setup RX Buffer
+    USBD_CDC_SetRxBuffer(&hUsbDeviceFS, usb_cdc_if.rx.irqBuf);
+    usb_cdc_if.rx.ctx = circular_buf_init(usb_cdc_if.rx.buf, sizeof(usb_cdc_if.rx.buf));
+
+    // Default is no host attached.
+    usb_cdc_if.isComPortOpen = false;
+
+    return (USBD_OK);
+}
+
+/**
+  * @brief  DeInitializes the CDC media low layer
+  * @retval USBD_OK if all operations are OK else USBD_FAIL
+  */
+static int8_t CDC_DeInit_FS(void)
+{
+    // Nothing hear, never called.
+    return (USBD_OK);
+}
+
+/**
+  * @brief  Manage the CDC class requests
+  * @param  cmd: Command code
+  * @param  pbuf: Buffer containing command data (request parameters)
+  * @param  length: Number of data to be sent (in bytes)
+  * @retval Result of the operation: USBD_OK if all operations are OK else USBD_FAIL
+  */
+static int8_t CDC_Control_FS(uint8_t cmd, uint8_t* pbuf, uint16_t length)
+{
+    switch(cmd)
+    {
+        case CDC_SEND_ENCAPSULATED_COMMAND:    break;
+        case CDC_GET_ENCAPSULATED_RESPONSE:    break;
+        case CDC_SET_COMM_FEATURE:             break;
+        case CDC_GET_COMM_FEATURE:             break;
+        case CDC_CLEAR_COMM_FEATURE:           break;
+
+    /*******************************************************************************/
+    /* Line Coding Structure                                                       */
+    /*-----------------------------------------------------------------------------*/
+    /* Offset | Field       | Size | Value  | Description                          */
+    /* 0      | dwDTERate   |   4  | Number |Data terminal rate, in bits per second*/
+    /* 4      | bCharFormat |   1  | Number | Stop bits                            */
+    /*                                        0 - 1 Stop bit                       */
+    /*                                        1 - 1.5 Stop bits                    */
+    /*                                        2 - 2 Stop bits                      */
+    /* 5      | bParityType |  1   | Number | Parity                               */
+    /*                                        0 - None                             */
+    /*                                        1 - Odd                              */
+    /*                                        2 - Even                             */
+    /*                                        3 - Mark                             */
+    /*                                        4 - Space                            */
+    /* 6      | bDataBits  |   1   | Number Data bits (5, 6, 7, 8 or 16).          */
+    /*******************************************************************************/
+    case CDC_SET_LINE_CODING:
+        LineCoding.bitrate = (uint32_t)(pbuf[0] | (pbuf[1] << 8) |
+                (pbuf[2] << 16) | (pbuf[3] << 24));
+        LineCoding.format = pbuf[4];
+        LineCoding.paritytype = pbuf[5];
+        LineCoding.datatype = pbuf[6];
+    break;
+
+    case CDC_GET_LINE_CODING:
+        pbuf[0] = (uint8_t)(LineCoding.bitrate);
+        pbuf[1] = (uint8_t)(LineCoding.bitrate >> 8);
+        pbuf[2] = (uint8_t)(LineCoding.bitrate >> 16);
+        pbuf[3] = (uint8_t)(LineCoding.bitrate >> 24);
+        pbuf[4] = LineCoding.format;
+        pbuf[5] = LineCoding.paritytype;
+        pbuf[6] = LineCoding.datatype;
+    break;
+
+    case CDC_SET_CONTROL_LINE_STATE:
+        usb_cdc_if.isComPortOpen = (((USBD_SetupReqTypedef *) pbuf)->wValue & 0x0001) != 0;
+    break;
+
+    case CDC_SEND_BREAK:    break;
+    default:                break;
+  }
+
+  return (USBD_OK);
+}
+
+/**
+  * @brief  Data received over USB OUT endpoint are sent over CDC interface
+  *         through this function.
+  *
+  *         @note
+  *         This function will issue a NAK packet on any OUT packet received on
+  *         USB endpoint until exiting this function. If you exit this function
+  *         before transfer is complete on CDC interface (ie. using DMA controller)
+  *         it will result in receiving more data while previous ones are still
+  *         not sent.
+  *
+  * @param  Buf: Buffer of data to be received
+  * @param  Len: Number of data received (in bytes)
+  * @retval Result of the operation: USBD_OK if all operations are OK else USBD_FAIL
+  */
+static int8_t CDC_Receive_FS(uint8_t* Buf, uint32_t *Len)
+{
+    USBD_CDC_SetRxBuffer(&hUsbDeviceFS, &Buf[0]);
+    USBD_CDC_ReceivePacket(&hUsbDeviceFS);
+
+    uint16_t len = (uint16_t)*Len;
+    // Update circular buffer with incoming values
+    for(uint8_t i = 0; i < len; i++)
+    {
+        circular_buf_put(usb_cdc_if.rx.ctx, Buf[i]);
+
+        // Checking for '\r' is there for debugging purposes which is sent by putty and minicom.
+        // In production only '\n' is sent. Therefore, there is no check for '\r\n' case.
+        if (Buf[i]=='\n'||Buf[i]=='\r')
+            circular_buf_add_input(usb_cdc_if.rx.ctx);
+    }
+    memset(Buf, '\0', len); // clear the buf
+
+    return (USBD_OK);
+}
+
+
+/**
+  * @brief  usb_cdc_rx
+  *         Check/receive data from the USB cdc device.
+  * @param  buf: pointer to receiver buffer
+  * @param  Len: length of buffer
+  * @retval no of bytes received.
+  */
+void usb_cdc_rx(uint8_t* buf)
+{
+    *buf = 0;
+    if (usb_cdc_if.rx.ctx)
+        circular_read_command(usb_cdc_if.rx.ctx, buf);
+}
+
+void usb_cdc_rx_flush()
+{
+    if (usb_cdc_if.rx.ctx)
+        circular_buf_reset(usb_cdc_if.rx.ctx);
+}
+
+/**
+  * @brief  CDC_Transmit_FS
+  *         Data to send over USB IN endpoint are sent over CDC interface
+  *         through this function.
+  *
+  * @param  Buf: Buffer of data to be sent
+  * @param  Len: Number of data to be sent (in bytes)
+  * @retval USBD_OK if all operations are OK else USBD_FAIL or USBD_BUSY
+  */
+uint8_t usb_cdc_transmit(uint8_t* Buf, uint16_t Len)
+{
+    if (!usb_cdc_if.tx.ctx)
+        return USBD_FAIL; // Assert on this?
+
+    uint8_t result = USBD_OK;
+
+    USBD_CDC_HandleTypeDef *hcdc = (USBD_CDC_HandleTypeDef*)hUsbDeviceFS.pClassData;
+
+    if (hcdc->TxState != 0)
+    {
+        // USB CDC is transmitting data to the network. Leave transmit handling to CDC_TransmitCplt_FS
+        for (int len = 0;len < Len; len++)
+        {
+            if (circular_buf_put2(usb_cdc_if.tx.ctx, *Buf))
+                break; // No more space in buffer.
+            Buf++;
+        }
+        return USBD_OK;
+    }
+
+    // Fill in the data from buffer directly, no need copy bytes
+    if (Len > sizeof(usb_cdc_if.tx.irqBuf))
+    {
+        // remaining bytes could be moved to circular buffer but in this case,
+        // system is possible in a lack of resources. That problem can not be solved hear.
+        Len = sizeof(usb_cdc_if.tx.irqBuf);
+    }
+
+    memcpy(usb_cdc_if.tx.irqBuf, Buf, Len);
+    USBD_CDC_SetTxBuffer(&hUsbDeviceFS, usb_cdc_if.tx.irqBuf, Len);
+    result = USBD_CDC_TransmitPacket(&hUsbDeviceFS);
+
+    return result;
+}
+
+/**
+  * @brief  CDC_TransmitCplt_FS
+  *         Data transmited callback
+  *
+  *         @note
+  *         This function is IN transfer complete callback used to inform user that
+  *         the submitted Data is successfully sent over USB.
+  *
+  * @param  Buf: Buffer of data to be received
+  * @param  Len: Number of data received (in bytes)
+  * @retval Result of the operation: USBD_OK if all operations are OK else USBD_FAIL
+  */
+static int8_t CDC_TransmitCplt_FS(uint8_t *Buf, uint32_t *Len, uint8_t epnum)
+{
+    uint8_t result = USBD_OK;
+
+    // Fill in the next number of bytes.
+    uint16_t len = 0;
+    for (uint8_t *ptr = usb_cdc_if.tx.irqBuf; ptr < &usb_cdc_if.tx.irqBuf[sizeof(usb_cdc_if.tx.irqBuf)]; ptr++)
+    {
+        if (circular_buf_get(usb_cdc_if.tx.ctx, ptr) != 0) {
+            break; // No more bytes ready to transmit.
+        }
+        len++; // Yet another byte to send.
+    }
+
+    if (len != 0)
+    {
+        USBD_CDC_SetTxBuffer(&hUsbDeviceFS, usb_cdc_if.tx.irqBuf, len);
+        result = USBD_CDC_TransmitPacket(&hUsbDeviceFS);
+    }
+
+    return result;
+}


### PR DESCRIPTION
This will make the HAL delay obsolete when sending upper/lower layer
design pattern. The new usb_cdc_fops module is also common for all modules.