### PR TITLE
Added CA protocol layer

### DIFF
--- a/STM32/Libraries/UnitTesting/CMakeLists.txt
+++ b/STM32/Libraries/UnitTesting/CMakeLists.txt
@@ -8,8 +8,11 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_FLAGS "-O0 -g3")
 set(CMAKE_C_FLAGS "-O0 -g3")
 
-include_directories(../ADCMonitor/Inc Inc)
+include_directories(../ADCMonitor/Inc
+                    ../Util/Inc
+                    ../USBprint/Inc
+                    Inc )
 
 enable_testing()
-add_executable(CA_UnitTesting  ../ADCMonitor/Src/ADCmonitor.c src/stubs.c)
+add_executable(CA_UnitTesting ../ADCMonitor/Src/ADCmonitor.c ../Util/Src/CAProtocol.c src/stubs.c)
 target_link_libraries(CA_UnitTesting PRIVATE m)

--- a/STM32/Libraries/UnitTesting/Inc/stm32f4xx_hal.h
+++ b/STM32/Libraries/UnitTesting/Inc/stm32f4xx_hal.h
@@ -17,6 +17,9 @@ typedef struct ADC_HandleTypeDef
 
 // HW depended functions
 void HAL_ADC_Start_DMA(ADC_HandleTypeDef* hadc, uint32_t* pData, uint32_t Length);
+void HAL_Delay(uint32_t);
+int USBnprintf(const char * format, ... );
+void JumpToBootloader();
 
 #ifdef __cplusplus
 }

--- a/STM32/Libraries/Util/Inc/CAProtocol.h
+++ b/STM32/Libraries/Util/Inc/CAProtocol.h
@@ -1,0 +1,36 @@
+/*
+ * CAProtocol.h
+ *
+ *  Created on: Oct 6, 2021
+ *      Author: agp
+ */
+
+#ifndef INC_CAPROTOCOL_H_
+#define INC_CAPROTOCOL_H_
+
+typedef struct
+{
+    int port;
+    double alpha;
+    double beta;
+} CACalibration;
+
+typedef struct
+{
+    // Called if message is not found. Overwrite to get info about invalid input
+    void (*undefined)(const char* inputString);
+
+    // system info request using "Serial". These should be overwritten
+    void (*printHeader)();
+    void (*jumpToBootLoader)();
+
+    // Calibration request. overwrite if calibration is supported by module.
+    void (*calibration)(int noOfCalibrations, const CACalibration* calibrations);
+
+    struct CAProtocolData *data; // Private data for CAProtocol.
+} CAProtocolCtx;
+
+void inputCAProtocol(CAProtocolCtx* ctx, const char *input);
+void initCAProtocol(CAProtocolCtx* ctx);
+
+#endif /* INC_CAPROTOCOL_H_ */

--- a/STM32/Libraries/Util/Inc/CAProtocolStm.h
+++ b/STM32/Libraries/Util/Inc/CAProtocolStm.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void HALundefined(const char *input);
+void HALJumpToBootloader();

--- a/STM32/Libraries/Util/Src/CAProtocol.c
+++ b/STM32/Libraries/Util/Src/CAProtocol.c
@@ -1,0 +1,80 @@
+/*
+ * CAProtocol.c
+ *
+ *  Created on: Oct 6, 2021
+ *      Author: agp
+ */
+#include <stdio.h>
+#include <string.h>
+#include <strings.h>
+#include <stdlib.h>
+#include "CAProtocol.h"
+
+typedef struct CAProtocolData {
+    // Nothing for now.
+} CAProtocolData;
+
+#define MAX_NO_CALIBRATION 12
+static void calibration(CAProtocolCtx* ctx, const char* input)
+{
+    char* idx = index(input, ' ');
+    CACalibration cal[MAX_NO_CALIBRATION];
+    int noOfCalibrations = 0;
+
+    if (!idx) {
+        ctx->undefined(input); // arguments.
+        return;
+    }
+
+    // Next follow a port,alpha,beta entry
+    while (idx != NULL && noOfCalibrations < MAX_NO_CALIBRATION)
+    {
+        int port;
+        double alpha, beta;
+        idx++;
+        if (sscanf(idx, "%d,%lf,%lf", &port, &alpha, &beta) == 3)
+        {
+            cal[noOfCalibrations] = (CACalibration) { port, alpha, beta };
+            noOfCalibrations++;
+        }
+        idx = index(idx, ' '); // get the next space.
+    }
+
+    if (noOfCalibrations != 0)
+    {
+        ctx->calibration(noOfCalibrations, cal);
+    }
+    else
+        ctx->undefined(input);
+}
+
+void inputCAProtocol(CAProtocolCtx* ctx, const char *input)
+{
+    if (input[0] == '\0') {
+        return; // Null terminated string.
+    }
+    else if(strcmp(input, "Serial") == 0)
+    {
+        if (ctx->printHeader)
+            ctx->printHeader();
+    }
+    else if(strcmp(input, "DFU") == 0)
+    {
+        if (ctx->jumpToBootLoader)
+            ctx->jumpToBootLoader();
+    }
+    else if (strcmp(input, "CAL"))
+    {
+        if (ctx->calibration)
+            calibration(ctx, input);
+    }
+    else if (ctx->undefined)
+    {
+        ctx->undefined(input);
+    }
+}
+
+void initCAProtocol(CAProtocolCtx* ctx)
+{
+    ctx->data = NULL; // no data for now, when needed => malloc(sizeof(CAProtocolData));
+}

--- a/STM32/Libraries/Util/Src/CAProtocolStm.c
+++ b/STM32/Libraries/Util/Src/CAProtocolStm.c
@@ -1,0 +1,19 @@
+#include <string.h>
+#include "CAProtocolStm.h"
+#include "USBprint.h"
+#include "jumpToBootloader.h"
+
+void HALundefined(const char *input)
+{
+    if(strcmp(input, "\0"))
+    {
+        USBnprintf("MISREAD: %s", input);
+    }
+}
+
+void HALJumpToBootloader()
+{
+    USBnprintf("Entering bootloader mode");
+    HAL_Delay(200);
+    JumpToBootloader();
+}


### PR DESCRIPTION
This layer should replace the HandleGeneric message layer. This "message layer"
is a sort of CA module protocol and should be handled as a protocol layer, i.e
data->layer->application.

This input (data) is sent to the layer via inputCAProtocol and application handlers
is defined in the struct CAProtocolCtx which is initialized via initCAProtocol.

This layer is introduced to make communication generic and prepare for common
calibration.