### PR TITLE
Changed interface for si7051 I2C device

### DIFF
--- a/STM32/DC/Core/Src/main.c
+++ b/STM32/DC/Core/Src/main.c
@@ -146,7 +146,10 @@ void printResult(int16_t *pBuffer, int noOfChannels, int noOfSamples)
     if (isFirstWrite)
         clearLineAndBuffer();
 
-    const double temp = si7051Temp(&hi2c1);
+    double temp;
+    if (si7051Temp(&hi2c1, &temp) != HAL_OK)
+        temp = 10000;
+
     USBnprintf("%.2f, %.2f, %.2f, %.2f, %.2f, %.2f, %d",
             meanCurrent(pBuffer, 0), meanCurrent(pBuffer, 1), meanCurrent(pBuffer, 2), meanCurrent(pBuffer, 3),
             temp, ADCrms(pBuffer, 5), ADCmax(pBuffer, 5));

--- a/STM32/Libraries/SI7051/Inc/si7051.h
+++ b/STM32/Libraries/SI7051/Inc/si7051.h
@@ -9,7 +9,7 @@
 #define INC_SI7051_H_
 
 #include "stm32f4xx_hal.h"
-float si7051Temp(I2C_HandleTypeDef *hi2c1);
+HAL_StatusTypeDef si7051Temp(I2C_HandleTypeDef *hi2c1, float* siValue);
 
 #endif /* INC_SI7051_H_ */
 

--- a/STM32/Libraries/SI7051/Src/si7051.c
+++ b/STM32/Libraries/SI7051/Src/si7051.c
@@ -10,7 +10,7 @@
 #define SI7051_I2C_ADDR          0x40
 #define SI7051_TEMPERATUR_OFFSET 0xF3
 
-float si7051Temp(I2C_HandleTypeDef *hi2c1)
+HAL_StatusTypeDef si7051Temp(I2C_HandleTypeDef *hi2c1, float* siValue)
 {
     uint8_t readSensorADDR = SI7051_TEMPERATUR_OFFSET;
 
@@ -25,7 +25,7 @@ float si7051Temp(I2C_HandleTypeDef *hi2c1)
         if (HAL_OK == ret)
         {
             uint16_t si7051_temp = addata[0] << 8 | addata[1];
-            return (175.72*si7051_temp) / 65536 - 46.85;
+            *siValue = (175.72*si7051_temp) / 65536 - 46.85;
         }
     }
 

--- a/STM32/Temperature/Core/Src/main.c
+++ b/STM32/Temperature/Core/Src/main.c
@@ -201,7 +201,9 @@ void readTemperatures(){
 
 	// On board temperature
 	HAL_Delay(1);
-	temperatures[TEMP_VALUES-1]=si7051Temp(&hi2c1);
+    if (si7051Temp(&hi2c1, &temperatures[TEMP_VALUES-1]) != HAL_OK) {
+        temperatures[TEMP_VALUES-1] = 10000;
+    }
 }
 
 void printTemperatures(void)


### PR DESCRIPTION
Temperature and error code was mixed, which made it difficult to
detect errors. Return Value is now error, while the temperature is
a pointer to float argument.