### PR TITLE
Issue 62, Flash Calibration sector must be reserved in ld linker script.

### DIFF
--- a/STM32/DC/Core/Src/main.c
+++ b/STM32/DC/Core/Src/main.c
@@ -146,7 +146,7 @@ void printResult(int16_t *pBuffer, int noOfChannels, int noOfSamples)
     if (isFirstWrite)
         clearLineAndBuffer();
 
-    double temp;
+    float temp;
     if (si7051Temp(&hi2c1, &temp) != HAL_OK)
         temp = 10000;
 

--- a/STM32/Libraries/FLASH_readwrite/Inc/FLASH_readwrite.h
+++ b/STM32/Libraries/FLASH_readwrite/Inc/FLASH_readwrite.h
@@ -1,24 +1,16 @@
-
 /*
 Library:			Read and write FLASH memory on STM32F411
-Written by:			Alexander Mizrahi-Werner (alexanderMizrahi@copenhagenAtomics.com)
-Last modified:		22-03-2021
-Description:
-					Provides an interface to read and write FLASH memory.
+Description:		Provides an interface to read and write FLASH memory.
 					Tested with STM32F411CE
-
-
-
 */
 
 #ifndef INC_FLASH_READWRITE_H_
 #define INC_FLASH_READWRITE_H_
 
-
-
-#endif /* INC_FLASH_READWRITE_H_ */
-#include "stm32f4xx_hal.h"
+#include <stdint.h>
 
 void writeToFlash(uint32_t indx, uint32_t size, uint8_t *dataToBeSaved);
-
 void readFromFlash(uint32_t indx, uint32_t size, uint8_t *dataToBeRead);
+
+#endif /* INC_FLASH_READWRITE_H_ */
+

--- a/STM32/Libraries/FLASH_readwrite/Src/FLASH_readwrite.c
+++ b/STM32/Libraries/FLASH_readwrite/Src/FLASH_readwrite.c
@@ -1,50 +1,43 @@
 
 /*
-Library:			Read and write FLASH memory on STM32F411
-Written by:			Alexander Mizrahi-Werner (alexanderMizrahi@copenhagenAtomics.com)
-Last modified:		22-03-2021
-Description:
-					Provides an interface to read and write FLASH memory.
-					Tested with STM32F411CE
-
-//minimum use case
-
-  HAL_Delay(500); //important! otherwise the program access the flash before the debugger can reset the STM32. This soft bricks the device
-  uint8_t dataWrite[4] = {1, 2, 3, 4};
-  uint8_t dataRead[4];
-
-  writeToFlash(0,4,dataWrite);
-  readFromFlash(0,4,dataRead);
-
+ *  Library:			Read and write FLASH memory on STM32F411
+ *  Description:		Provides an interface to read and write FLASH memory.
+ *  TODO: This is a very brute force implementation where no 'protocol' is used
+ *        to read/write the flash. So flash layout should be defined.
 */
 
-#include "FLASH_readwrite.h"
-#include "stm32f4xx_hal.h"
+#include <FLASH_readwrite.h>
+#include <stm32f4xx_hal.h>
 
+// NOTE: The flash sector and addr variables originate from the ld linker script.
+// The flash is used for program data and this must NOT be cleared. Putting data in
+// linker script will ensure that program data will not be cleared when writing
+// calibration data to the flash. To access these variables the syntax below is used.
+extern uint32_t _FlashSector; // Variable defined in ld linker script.
+extern uint32_t _FlashAddr;   // Variable defined in ld linker script.
+#define FLASH_SECTOR ((uint32_t) &_FlashSector)
+#define FLASH_ADDR   ((uint32_t) &_FlashAddr)
 
-void writeToFlash(uint32_t indx, uint32_t size, uint8_t *dataToBeSaved){
-	//sector 5 is the last sector of the memory on F401CC, this such that it will interfere with the main program and vice versa.
-	uint8_t sector = 5;
-	//Write address within sector 5
-	uint32_t flashAddress = 0x08020000;
+void writeToFlash(uint32_t indx, uint32_t size, uint8_t *dataToBeSaved)
+{
+    // Erase the sector before write
+    HAL_FLASH_Unlock();
+    FLASH_Erase_Sector(FLASH_SECTOR, FLASH_VOLTAGE_RANGE_3);
+    HAL_FLASH_Lock();
 
-	//Erase the sector before write
-	HAL_FLASH_Unlock();
-	FLASH_Erase_Sector(sector, FLASH_VOLTAGE_RANGE_3);
-	HAL_FLASH_Lock();
-
-	//Write to sector
-	HAL_FLASH_Unlock();
-    for(uint32_t i=0; i<size; i++){
-    	HAL_FLASH_Program(FLASH_TYPEPROGRAM_BYTE, flashAddress+indx+i , dataToBeSaved[i]);
-	}
+    // Write to sector
+    HAL_FLASH_Unlock();
+    for(uint32_t i=0; i<size; i++)
+    {
+        HAL_FLASH_Program(FLASH_TYPEPROGRAM_BYTE, FLASH_ADDR+indx+i , dataToBeSaved[i]);
+    }
     HAL_FLASH_Lock();
 }
 
-void readFromFlash(uint32_t indx, uint32_t size, uint8_t *dataToBeRead){
-	uint32_t flashAddress = 0x08020000;
-	for(uint32_t i=0; i<size; i++)
-	{
-		*((uint8_t *)dataToBeRead + i) = *((uint8_t *)flashAddress+indx+i);
-	}
+void readFromFlash(uint32_t indx, uint32_t size, uint8_t *dataToBeRead)
+{
+    for(uint32_t i=0; i<size; i++)
+    {
+        *((uint8_t *)dataToBeRead + i) = *( (uint8_t *)(FLASH_SECTOR+indx+i) );
+    }
 }


### PR DESCRIPTION
This should be done to ensure that write of calibration data will not
clear sections of the program data (.text etc).