### PR TITLE
USB CDC, Added real write for enahanced control.

### DIFF
--- a/STM32/Libraries/USBprint/Inc/USBprint.h
+++ b/STM32/Libraries/USBprint/Inc/USBprint.h
@@ -8,6 +8,7 @@
 #ifndef INC_USBPRINT_H_
 #define INC_USBPRINT_H_
 
+#include <unistd.h>
 #include "stm32f4xx_hal.h"
 #include "stdarg.h"
 
@@ -15,5 +16,11 @@
 // and send data to USB port. The n indicates that buffer overflow is handled.
 // String/n is max 256 bytes.
 int USBnprintf(const char * format, ... );
+
+// Same interface ansi C write, same return values.
+ssize_t writeUSB(const void *buf, size_t count);
+
+// Return the number of bytes possible to write to buffer.
+size_t txAvailable();
 
 #endif /* INC_USBPRINT_H_ */

--- a/STM32/Libraries/USBprint/Inc/usb_cdc_fops.h
+++ b/STM32/Libraries/USBprint/Inc/usb_cdc_fops.h
@@ -28,7 +28,8 @@ extern USBD_CDC_ItfTypeDef usb_cdc_fops;
 
 #define CIRCULAR_BUFFER_SIZE 1024
 
-uint8_t usb_cdc_transmit(uint8_t* Buf, uint16_t len);
+ssize_t usb_cdc_transmit(const uint8_t* Buf, uint16_t len);
+size_t usb_cdc_tx_available();
 // Note, it assumed that buf is of size CIRCULAR_BUFFER_SIZE
 void usb_cdc_rx(uint8_t* buf);
 void usb_cdc_rx_flush();

--- a/STM32/Libraries/USBprint/Src/USBprint.c
+++ b/STM32/Libraries/USBprint/Src/USBprint.c
@@ -25,3 +25,13 @@ int USBnprintf(const char * format, ... )
     usb_cdc_transmit((uint8_t*)buffer, len);
     return len;
 }
+
+ssize_t writeUSB(const void *buf, size_t count)
+{
+    return usb_cdc_transmit(buf, count);
+}
+
+size_t txAvailable()
+{
+    return usb_cdc_tx_available();
+}


### PR DESCRIPTION
This is needed when bufferes are big and transmissions might be cut in two. This is
not possible when using the formateded USBnprintf.