### PR TITLE
Dev/agp/ot pv2

### DIFF
--- a/STM32/AC/Core/Src/ACBoard.c
+++ b/STM32/AC/Core/Src/ACBoard.c
@@ -32,7 +32,6 @@ static struct
 // Forward declare functions.
 static void handlePinInput(const char *input);
 static void printHeader();
-static void otpRead();
 
 static CAProtocolCtx caProto =
 {
@@ -42,30 +41,13 @@ static CAProtocolCtx caProto =
         .calibration = NULL, // TODO: change method for calibration?
         .calibrationRW = NULL,
         .logging = NULL,
-        .otpRead = otpRead,
+        .otpRead = CAotpRead,
         .otpWrite = NULL
 };
 
 static void printHeader()
 {
     USBnprintf(systemInfo());
-}
-static void otpRead()
-{
-    BoardInfo info;
-    if (HAL_otpRead(&info))
-    {
-        USBnprintf("OTP: No production available");
-    }
-    else
-    {
-        USBnprintf("OTP %u %u %u.%u %u\r\n"
-                , info.otpVersion
-                , info.v1.boardType
-                , info.v1.pcbVersion.major
-                , info.v1.pcbVersion.minor
-                , info.v1.productionDate);
-    }
 }
 
 static void GpioInit()

--- a/STM32/DC/Core/Src/DCBoard.c
+++ b/STM32/DC/Core/Src/DCBoard.c
@@ -40,7 +40,6 @@
 static void clearLineAndBuffer();
 static void printHeader();
 static void userPinCmds(const char* inputString);
-static void otpRead();
 
 // Local variables.
 static CAProtocolCtx caProto =
@@ -51,7 +50,7 @@ static CAProtocolCtx caProto =
         .calibration = NULL,
         .calibrationRW = NULL,
         .logging = NULL,
-        .otpRead = otpRead,
+        .otpRead = CAotpRead,
         .otpWrite = NULL
 };
 
@@ -63,24 +62,6 @@ static uint32_t ccr_states[ACTUATIONPORTS] = { 0 };
 
 // Temperature handling
 static I2C_HandleTypeDef *hi2c = NULL;
-
-static void otpRead()
-{
-    BoardInfo info;
-    if (HAL_otpRead(&info))
-    {
-        USBnprintf("OTP: No production available");
-    }
-    else
-    {
-        USBnprintf("OTP %u %u %u.%u %u\r\n"
-                , info.otpVersion
-                , info.v1.boardType
-                , info.v1.pcbVersion.major
-                , info.v1.pcbVersion.minor
-                , info.v1.productionDate);
-    }
-}
 
 static void printHeader()
 {

--- a/STM32/Libraries/FLASH_readwrite/Inc/HAL_otp.h
+++ b/STM32/Libraries/FLASH_readwrite/Inc/HAL_otp.h
@@ -5,12 +5,13 @@
 // Only defined formats will be supported. If code/version is bumped, it MUST be possible to read
 // old data in the OTP area since this is fixed (for ever).
 #define OTP_VERSION_1   0x01 // First version of the production data.
-#define OTP_VERSION     OTP_VERSION_1 // Current version of the OTP writer format.
+#define OTP_VERSION_2   0x02
+#define OTP_VERSION     OTP_VERSION_2 // Current version of the OTP writer format.
 
 // Error codes.
-#define OTP_SUCCESS     0 // read/write operation success.
-#define OTP_EMPTY       1 // if read operation is done
-#define OTP_WRITE_FAIL  2 // content could not be written to OTP area.
+#define OTP_SUCCESS         0 // read/write operation success.
+#define OTP_EMPTY           1 // if read operation is done
+#define OTP_WRITE_FAIL      2 // content could not be written to OTP area.
 
 // Union for all known production data written in OTP.
 typedef union BoardInfo
@@ -25,10 +26,22 @@ typedef union BoardInfo
         struct {
             uint8_t major;
             uint8_t minor;
-        } pcbVersion;             // The PCB version during production. This will make it possible to new SW on old boards.format if <major><minor>
+        } pcbVersion;                    // The PCB version during production. This will make it possible to new SW on old boards.format if <major><minor>
         uint32_t productionDate;         // Production date, used to trace when/where stuff was made.
     } v1;
-    // future versions of the OPT data.
+
+    struct {
+        uint8_t  otpVersion;             // Note OTP version must be located at the first byte (due to union type at top)
+        uint8_t  boardType;              // BoardType. This is a fixed table of different board types (fixed)
+        uint8_t  subBoardType;           // Some boards can have different peripherals soldered directly to the PCB.
+        uint8_t  reserved[3];            // Reserved for future use. ProductionDate must start at address modulus 4.
+        struct {
+            uint8_t major;
+            uint8_t minor;
+        } pcbVersion;                    // The PCB version during production. This will make it possible to new SW on old boards.format if <major><minor>
+        uint32_t productionDate;         // Production date, used to trace when/where stuff was made.
+    } v2;
+// future versions of the OPT data.
 } BoardInfo;
 
 // Read the current content of the OTP data.

--- a/STM32/Libraries/FLASH_readwrite/Src/HAL_otp.c
+++ b/STM32/Libraries/FLASH_readwrite/Src/HAL_otp.c
@@ -63,8 +63,14 @@ const int HAL_otpWrite(const BoardInfo *boardInfo)
     sector = (sector < 0) ? 0 : sector+1;
 
     // Check if the OTP section is within the OTP area.
-    if (sector >= OTP_SECTIONS)
+    if (sector >= OTP_SECTIONS) {
         return OTP_WRITE_FAIL;
+    }
+
+    // Check the version of the Board info
+    if (boardInfo->otpVersion > OTP_VERSION || boardInfo->otpVersion == 0) {
+        return OTP_WRITE_FAIL;
+    }
 
     if(HAL_FLASH_Unlock() != HAL_OK) {
         return OTP_WRITE_FAIL;

--- a/STM32/Libraries/Util/Inc/CAProtocolStm.h
+++ b/STM32/Libraries/Util/Inc/CAProtocolStm.h
@@ -2,3 +2,4 @@
 
 void HALundefined(const char *input);
 void HALJumpToBootloader();
+void CAotpRead();

--- a/STM32/Libraries/Util/Src/CAProtocolStm.c
+++ b/STM32/Libraries/Util/Src/CAProtocolStm.c
@@ -2,6 +2,7 @@
 #include "CAProtocolStm.h"
 #include "USBprint.h"
 #include "jumpToBootloader.h"
+#include "HAL_otp.h"
 
 void HALundefined(const char *input)
 {
@@ -18,3 +19,37 @@ void HALJumpToBootloader()
     JumpToBootloader();
 }
 
+void CAotpRead()
+{
+    BoardInfo info;
+    if (HAL_otpRead(&info))
+    {
+        USBnprintf("OTP: No production available");
+    }
+    else
+    {
+        switch(info.otpVersion)
+        {
+        case OTP_VERSION_1:
+            USBnprintf("OTP %u %u %u.%u %u\r\n"
+                     , info.otpVersion
+                     , info.v1.boardType
+                     , info.v1.pcbVersion.major
+                     , info.v1.pcbVersion.minor
+                     , info.v1.productionDate);
+            break;
+        case OTP_VERSION_2:
+            USBnprintf("OTP %u %u %u %u.%u %u\r\n"
+                     , info.otpVersion
+                     , info.v2.boardType
+                     , info.v2.subBoardType
+                     , info.v2.pcbVersion.major
+                     , info.v2.pcbVersion.minor
+                     , info.v2.productionDate);
+            break;
+        default:
+            USBnprintf("Not supported version %d of OTP data. Update firmware in board.", info.otpVersion);
+            break;
+        }
+    }
+}

--- a/STM32/Libraries/Util/Src/systeminfo.c
+++ b/STM32/Libraries/Util/Src/systeminfo.c
@@ -60,20 +60,40 @@ const char* systemInfo()
 
     if (HAL_otpRead(&info) != OTP_SUCCESS)
     {
-        info.v1.boardType = 0;
-        info.v1.pcbVersion.major = 0;
-        info.v1.pcbVersion.minor = 0;
-        info.v1.otpVersion = 0;
+        info.otpVersion = 0; // Invalid OTP version
     }
 
     int len = 0;
     len  = snprintf(&buf[len], sizeof(buf) - len, "Serial Number: %lX%lX%lX\r\n", ID1, ID2, ID3);
-    len += snprintf(&buf[len], sizeof(buf) - len, "Product Type: %s\r\n", productType(info.v1.boardType));
+    switch(info.otpVersion)
+    {
+    case OTP_VERSION_1:
+        len += snprintf(&buf[len], sizeof(buf) - len, "Product Type: %s\r\n", productType(info.v1.boardType));
+        break;
+    case OTP_VERSION_2:
+        len += snprintf(&buf[len], sizeof(buf) - len, "Product Type: %s\r\n", productType(info.v2.boardType));
+        len += snprintf(&buf[len], sizeof(buf) - len, "Sub Product Type: %u\r\n", info.v2.subBoardType);
+        break;
+    default:
+        len += snprintf(&buf[len], sizeof(buf) - len, "Product Type: NA\r\n");
+        break;
+    }
     len += snprintf(&buf[len], sizeof(buf) - len, "MCU Family: %s\r\n", mcuType());
     len += snprintf(&buf[len], sizeof(buf) - len, "Software Version: %s\r\n", GIT_VERSION);
     len += snprintf(&buf[len], sizeof(buf) - len, "Compile Date: %s\r\n", GIT_DATE);
     len += snprintf(&buf[len], sizeof(buf) - len, "Git SHA %s\r\n", GIT_SHA);
-    len += snprintf(&buf[len], sizeof(buf) - len, "PCB Version: %d.%d", info.v1.pcbVersion.major, info.v1.pcbVersion.minor);
+    switch(info.otpVersion)
+    {
+    case OTP_VERSION_1:
+        len += snprintf(&buf[len], sizeof(buf) - len, "PCB Version: %d.%d", info.v1.pcbVersion.major, info.v1.pcbVersion.minor);
+        break;
+    case OTP_VERSION_2:
+        len += snprintf(&buf[len], sizeof(buf) - len, "PCB Version: %d.%d", info.v2.pcbVersion.major, info.v2.pcbVersion.minor);
+        break;
+    default:
+        len += snprintf(&buf[len], sizeof(buf) - len, "PCB Version: NA");
+        break;
+    }
 
     return buf;
 }

--- a/STM32/OTP/Core/Src/otpApp.c
+++ b/STM32/OTP/Core/Src/otpApp.c
@@ -14,7 +14,6 @@
 #include "USBprint.h"
 
 static void printHeader();
-static void otpRead();
 static void otpWrite(BoardInfo *boardInfo);
 
 // Local variables
@@ -26,48 +25,13 @@ static CAProtocolCtx caProto =
         .calibration = NULL,
         .calibrationRW = NULL,
         .logging = NULL,
-        .otpRead  = otpRead,
+        .otpRead  = CAotpRead,
         .otpWrite = otpWrite
 };
 
 static void printHeader()
 {
     USBnprintf(systemInfo());
-}
-
-static void otpRead()
-{
-    BoardInfo info;
-    if (HAL_otpRead(&info))
-    {
-        USBnprintf("OTP: No production available");
-    }
-    else
-    {
-        switch(info.otpVersion)
-        {
-        case OTP_VERSION_1:
-            USBnprintf("OTP %u %u %u.%u %u\r\n"
-                     , info.otpVersion
-                     , info.v1.boardType
-                     , info.v1.pcbVersion.major
-                     , info.v1.pcbVersion.minor
-                     , info.v1.productionDate);
-            break;
-        case OTP_VERSION_2:
-            USBnprintf("OTP %u %u %u %u.%u %u\r\n"
-                     , info.otpVersion
-                     , info.v2.boardType
-                     , info.v2.subBoardType
-                     , info.v2.pcbVersion.major
-                     , info.v2.pcbVersion.minor
-                     , info.v2.productionDate);
-            break;
-        default:
-            USBnprintf("Not supported version of OTP data. Update firmware in board.");
-            break;
-        }
-    }
 }
 
 static void otpWrite(BoardInfo *boardInfo)

--- a/STM32/OTP/Core/Src/otpApp.c
+++ b/STM32/OTP/Core/Src/otpApp.c
@@ -44,12 +44,29 @@ static void otpRead()
     }
     else
     {
-        USBnprintf("OTP %u %u %u.%u %u\r\n"
-                , info.otpVersion
-                , info.v1.boardType
-                , info.v1.pcbVersion.major
-                , info.v1.pcbVersion.minor
-                , info.v1.productionDate);
+        switch(info.otpVersion)
+        {
+        case OTP_VERSION_1:
+            USBnprintf("OTP %u %u %u.%u %u\r\n"
+                     , info.otpVersion
+                     , info.v1.boardType
+                     , info.v1.pcbVersion.major
+                     , info.v1.pcbVersion.minor
+                     , info.v1.productionDate);
+            break;
+        case OTP_VERSION_2:
+            USBnprintf("OTP %u %u %u %u.%u %u\r\n"
+                     , info.otpVersion
+                     , info.v2.boardType
+                     , info.v2.subBoardType
+                     , info.v2.pcbVersion.major
+                     , info.v2.pcbVersion.minor
+                     , info.v2.productionDate);
+            break;
+        default:
+            USBnprintf("Not supported version of OTP data. Update firmware in board.");
+            break;
+        }
     }
 }
 

--- a/STM32/Temperature/Core/Src/Temperature.c
+++ b/STM32/Temperature/Core/Src/Temperature.c
@@ -28,7 +28,9 @@ static CAProtocolCtx caProto =
         .jumpToBootLoader = HALJumpToBootloader,
         .calibration = NULL,
         .calibrationRW = NULL,
-        .logging = NULL
+        .logging = NULL,
+        .otpRead = CAotpRead,
+        .otpWrite = NULL
 };
 
 /* Actuation pin outs */


### PR DESCRIPTION
Two commits
commit 7a1575829d239ae2fd8d8042ae6c9219d6638062 (HEAD -> main, origin/dev/agp/OTPv2)
Author: Anders Gnistrup <anders.gnistrup@copenhagenatomics.com>
Date:   Tue Feb 1 12:00:29 2022 +0100

    Issue #114, Made function to read OTP data public.
    
    Moved to CAProtocolStm since it require HW access.
    Update AC Board, DC Board and Temperature Board to use the new funtion.

commit cea69cb3034fcc6647d5d57ca9d381bd64aa4dec
Author: Anders Gnistrup <anders.gnistrup@copenhagenatomics.com>
Date:   Tue Feb 1 11:46:59 2022 +0100

    Issue #114, Added Sub Board Type to OTP data.
    
    This is needed for the FlowChip where different sensors is added to the
    same PCB.

