### PR TITLE
Issue #45, Disable buttons on AC Board

### DIFF
--- a/STM32/AC/HeatCtrl/Src/HeatCtrl.c
+++ b/STM32/AC/HeatCtrl/Src/HeatCtrl.c
@@ -45,13 +45,6 @@ void heaterLoop()
 
     for(HeatCtrl *pCtrl = heaters; pCtrl < &heaters[noOfHeaters]; pCtrl++)
     {
-        // Check is user is pressing the button
-        if (!pCtrl->button->get(pCtrl->button))
-        {
-            pCtrl->heater->set(pCtrl->heater, true);
-            continue;
-        }
-
         uint32_t tdiff = tdiff_u32(now, pCtrl->periodBegin);
         if (tdiff > pCtrl->pwmDuration)
         {

--- a/STM32/AC/makefile.init
+++ b/STM32/AC/makefile.init
@@ -1,6 +1,6 @@
 # git commit version and date
 
-GIT_VERSION := $(shell git --no-pager describe --tags --always --dirty)
+GIT_VERSION := $(shell git --no-pager describe --always --dirty)
 GIT_DATE := $(firstword $(shell git --no-pager show --date=short --format="%ad" --name-only))
 GIT_SHA := $(shell git rev-parse HEAD)
 

--- a/STM32/Libraries/Util/Src/systeminfo.c
+++ b/STM32/Libraries/Util/Src/systeminfo.c
@@ -55,7 +55,7 @@ static char* productType(uint8_t id)
 
 const char* systemInfo()
 {
-    static char buf[500] = { 0 };
+    static char buf[600] = { 0 };
     BoardInfo info = { 0 };
 
     if (HAL_otpRead(&info) != OTP_SUCCESS)

--- a/STM32/Temperature/makefile.init
+++ b/STM32/Temperature/makefile.init
@@ -1,6 +1,6 @@
 # git commit version and date
 
-GIT_VERSION := $(shell git --no-pager describe --tags --always --dirty)
+GIT_VERSION := $(shell git --no-pager describe --always --dirty)
 GIT_DATE := $(firstword $(shell git --no-pager show --date=short --format="%ad" --name-only))
 GIT_SHA := $(shell git rev-parse HEAD)
 


### PR DESCRIPTION
If the heatsink gets to hot it will melt the calbe connection the
buttons. This is bad since a short will trigger a heater to be always
on.