### PR TITLE
Issue #78, Disable clock source for watchdog

### DIFF
--- a/STM32/AC/Core/Src/main.c
+++ b/STM32/AC/Core/Src/main.c
@@ -84,7 +84,7 @@ int main(void)
   SystemClock_Config();
 
   /* USER CODE BEGIN SysInit */
-  const char *bootMsg = CAonBoot(&hwwdg);
+  const char *bootMsg = CAonBoot();
   /* USER CODE END SysInit */
 
   /* Initialize all configured peripherals */

--- a/STM32/DC/Core/Src/main.c
+++ b/STM32/DC/Core/Src/main.c
@@ -94,7 +94,7 @@ int main(void)
   SystemClock_Config();
 
   /* USER CODE BEGIN SysInit */
-  const char *bootMsg = CAonBoot(&hwwdg);
+  const char *bootMsg = CAonBoot();
   /* USER CODE END SysInit */
 
   /* Initialize all configured peripherals */

--- a/STM32/Libraries/FLASH_readwrite/Src/FLASH_readwrite.c
+++ b/STM32/Libraries/FLASH_readwrite/Src/FLASH_readwrite.c
@@ -20,6 +20,7 @@ extern uint32_t _FlashAddr;   // Variable defined in ld linker script.
 
 void writeToFlash(uint32_t indx, uint32_t size, uint8_t *dataToBeSaved)
 {
+    __HAL_RCC_WWDG_CLK_DISABLE();
     // Erase the sector before write
     HAL_FLASH_Unlock();
     FLASH_Erase_Sector(FLASH_SECTOR, FLASH_VOLTAGE_RANGE_3);
@@ -32,6 +33,7 @@ void writeToFlash(uint32_t indx, uint32_t size, uint8_t *dataToBeSaved)
         HAL_FLASH_Program(FLASH_TYPEPROGRAM_BYTE, FLASH_ADDR+indx+i , dataToBeSaved[i]);
     }
     HAL_FLASH_Lock();
+    __HAL_RCC_WWDG_CLK_ENABLE();
 }
 
 void readFromFlash(uint32_t indx, uint32_t size, uint8_t *dataToBeRead)

--- a/STM32/Libraries/Util/Inc/CAProtocolStm.h
+++ b/STM32/Libraries/Util/Inc/CAProtocolStm.h
@@ -7,7 +7,7 @@ void CAPrintHeader();
 void CAotpRead();
 
 // analyse reason for boot and in case of SW reset jump to DFU SW update.
-const char* CAonBoot(WWDG_HandleTypeDef *hwwg);
+const char* CAonBoot();
 
 // Generic handler for a CAProtocolCtx handler.
 void CAhandleUserInputs(CAProtocolCtx* ctx, const char* startMsg);

--- a/STM32/Temperature/Core/Src/main.c
+++ b/STM32/Temperature/Core/Src/main.c
@@ -88,7 +88,7 @@ int main(void)
   SystemClock_Config();
 
   /* USER CODE BEGIN SysInit */
-  const char *bootMsg = CAonBoot(&hwwdg);
+  const char *bootMsg = CAonBoot();
   /* USER CODE END SysInit */
 
   /* Initialize all configured peripherals */


### PR DESCRIPTION
It is correct that the WatchDog can not be disabled once started, but
the clock source for the WatchDog can be disabled which indirectly
disables the HW Watchdog.

Also added a WatchDog Clock Source disable in Flash write operation
since that takes to much time to complete.