### PR TITLE
Do not copy a singleton, use a reference (pointer)

### DIFF
--- a/STM32/AirconCtrl/Core/Inc/airconCtrl.h
+++ b/STM32/AirconCtrl/Core/Inc/airconCtrl.h
@@ -8,7 +8,9 @@
 #ifndef INC_AIRCONCTRL_H_
 #define INC_AIRCONCTRL_H_
 
-void airconCtrlInit();
+#include "stm32f4xx_hal.h"
+
+void airconCtrlInit(TIM_HandleTypeDef *ctx);
 void airconCtrlLoop();
 
 #endif /* INC_AIRCONCTRL_H_ */

--- a/STM32/AirconCtrl/Core/Src/airconCtrl.c
+++ b/STM32/AirconCtrl/Core/Src/airconCtrl.c
@@ -12,8 +12,7 @@
 #include "usb_cdc_fops.h"
 #include "stm32f4xx_hal_tim.h"
 
-static CAProtocolCtx caProto =
-{
+static CAProtocolCtx caProto = {
         .undefined = NULL,
         .printHeader = CAPrintHeader,
         .jumpToBootLoader = HALJumpToBootloader,
@@ -28,60 +27,63 @@ uint32_t tempCode;
 uint8_t bitIndex;
 uint8_t cmd;
 uint8_t cmdli;
-TIM_HandleTypeDef  timerHandel;
+TIM_HandleTypeDef *timerCtx;
 
-void airconCtrlInit(TIM_HandleTypeDef htim1)
+void airconCtrlInit(TIM_HandleTypeDef *ctx)
 {
-	timerHandel = htim1;
-	initCAProtocol(&caProto, usb_cdc_rx);
-    HAL_TIM_Base_Start(&timerHandel);
-    __HAL_TIM_SET_COUNTER(&timerHandel, 0);
-
+    timerCtx = ctx;
+    initCAProtocol(&caProto, usb_cdc_rx);
+    HAL_TIM_Base_Start(timerCtx);
+    __HAL_TIM_SET_COUNTER(timerCtx, 0);
 }
 
+static int irqCnt;
 void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin)
 {
-  if(GPIO_Pin == GPIO_PIN_11)
-  {
-    if (__HAL_TIM_GET_COUNTER(&timerHandel) > 8000)
+    if (GPIO_Pin == GPIO_PIN_7)
     {
-      tempCode = 0;
-      bitIndex = 0;
+        irqCnt++;
+        if (__HAL_TIM_GET_COUNTER(timerCtx) > 8000)
+        {
+            tempCode = 0;
+            bitIndex = 0;
+        }
+        else if (__HAL_TIM_GET_COUNTER(timerCtx) > 1700)
+        {
+            tempCode |= (1UL << (31 - bitIndex));   // write 1
+            bitIndex++;
+        }
+        else if (__HAL_TIM_GET_COUNTER(timerCtx) > 1000)
+        {
+            tempCode &= ~(1UL << (31 - bitIndex));  // write 0
+            bitIndex++;
+        }
+        if (bitIndex == 32)
+        {
+            cmdli = ~tempCode; // Logical inverted last 8 bits
+            cmd = tempCode >> 8; // Second last 8 bits
+            if (cmdli == cmd) // Check for errors
+            {
+                USBnprintf("%d", tempCode);
+            }
+            bitIndex = 0;
+        }
+        __HAL_TIM_SET_COUNTER(timerCtx, 0);
     }
-    else if (__HAL_TIM_GET_COUNTER(&timerHandel) > 1700)
-    {
-      tempCode |= (1UL << (31-bitIndex));   // write 1
-      bitIndex++;
-    }
-    else if (__HAL_TIM_GET_COUNTER(&timerHandel) > 1000)
-    {
-      tempCode &= ~(1UL << (31-bitIndex));  // write 0
-      bitIndex++;
-    }
-    if(bitIndex == 32)
-    {
-      cmdli = ~tempCode; // Logical inverted last 8 bits
-      cmd = tempCode >> 8; // Second last 8 bits
-      if(cmdli == cmd) // Check for errors
-      {
-	    USBnprintf("%d", tempCode);
-      }
-      bitIndex = 0;
-    }
-    __HAL_TIM_SET_COUNTER(&timerHandel, 0);
-  }
 }
 
 void airconCtrlLoop()
 {
-	static uint32_t tStamp = 0;
+    static int loops = 0;
+    static uint32_t tStamp = 0;
 
-	inputCAProtocol(&caProto);
+    inputCAProtocol(&caProto);
 
-	if (tdiff_u32(HAL_GetTick(), tStamp) > 1000)
-	{
-		tStamp = HAL_GetTick();
-		USBnprintf("Hello world\r\n");
-	}
+    if (tdiff_u32(HAL_GetTick(), tStamp) > 1000)
+    {
+        tStamp = HAL_GetTick();
+        loops++;
+        USBnprintf("%d: irqCnt(%d)\r\n", loops, irqCnt);
+    }
 }
 


### PR DESCRIPTION
It is not possible to copy any of the initialized contexts pointing
to a specific piece of HW since it is a singleton. In this case a pointer
must be used.

Tested on board using a remote. A lot of interrupts was generated.
Also, it is not pin 11 but 7 (SDA is connected to PB7).