### PR TITLE
Update SHT35 library

### DIFF
--- a/STM32/Libraries/SHT35/Inc/sht35.h
+++ b/STM32/Libraries/SHT35/Inc/sht35.h
@@ -36,9 +36,7 @@ typedef enum
 	SHT3X_COMMAND_MEASURE_LOWREP_10HZ = 0x272a
 } sht3x_command_t;
 
-static uint8_t calculate_crc(const uint8_t *data, size_t length);
 HAL_StatusTypeDef sht3x_send_command(sht3x_handle_t *handle, sht3x_command_t command);
-static uint16_t uint8Merge(uint8_t msb, uint8_t lsb);
 HAL_StatusTypeDef sht3x_init(sht3x_handle_t *handle);
 HAL_StatusTypeDef sht3x_read_temperature_and_humidity(sht3x_handle_t *handle, float *temperature, float *humidity);
 

--- a/STM32/Libraries/SHT35/Src/sht35.c
+++ b/STM32/Libraries/SHT35/Src/sht35.c
@@ -6,10 +6,8 @@
  */
 
 #include "sht35.h"
-
 #include <assert.h>
 
-I2C_HandleTypeDef hi2c1;
 HAL_StatusTypeDef ret;
 
 


### PR DESCRIPTION
Removal of static functions definition in header file. 

Until now it has only caused warnings, but is may potentially cause some errors. 