### PR TITLE
Reinitialise ADS1120 chip when initializing fails

### DIFF
--- a/STM32/Temperature/Core/Src/Temperature.c
+++ b/STM32/Temperature/Core/Src/Temperature.c
@@ -153,6 +153,8 @@ void LoopTemperature(const char* bootMsg)
             else
             {
                 USBnprintf("Failed to initialise ADS1120 device %X. This SW require PCB version >= 5.2", spiErr);
+                USBnprintf("Re-initialising ADS1120 device");
+                spiErr = initSpiDevices(hspi);
             }
         }
     }


### PR DESCRIPTION
The ADS1120 chip has shown to fail initialization on a few occasions and is normally fixed, when power cycling the board or when a COM port is closed and re-opened i.e. initialization is reattempted. 

The latter means that another try of initializing the chips will probably solve the issue. 