### PR TITLE
ADC threshold added to calibration

### DIFF
--- a/STM32/Libraries/Util/Inc/CAProtocol.h
+++ b/STM32/Libraries/Util/Inc/CAProtocol.h
@@ -16,6 +16,7 @@ typedef struct
     int port;
     double alpha;
     double beta;
+    int threshold;
 } CACalibration;
 
 typedef int (*ReaderFn)(uint8_t* rxBuf);

--- a/STM32/Libraries/Util/Src/CAProtocol.c
+++ b/STM32/Libraries/Util/Src/CAProtocol.c
@@ -39,10 +39,14 @@ static void calibration(CAProtocolCtx* ctx, const char* input)
     {
         int port;
         double alpha, beta;
+        int threshold;
         idx++;
-        if (sscanf(idx, "%d,%lf,%lf", &port, &alpha, &beta) == 3)
+        // Threshold is optional and therefore only 3 values need to be set.
+        // For any board that uses the threshold value an additional check should
+        // be made before using for any calibration.
+        if (sscanf(idx, "%d,%lf,%lf,%d", &port, &alpha, &beta, &threshold) >= 3)
         {
-            cal[noOfCalibrations] = (CACalibration) { port, alpha, beta };
+            cal[noOfCalibrations] = (CACalibration) { port, alpha, beta, threshold };
             noOfCalibrations++;
         }
         idx = index(idx, ' '); // get the next space.


### PR DESCRIPTION
Calibration command:

**CAL port, alpha, beta** is now changed to **CAL port, alpha, beta, threshold**

This allows the Salt Flow board to calibrate on the threshold where flow is detected. This is useful because different systems yields different signal strengths. 

Threshold is optional to not break format with other boards. Therefore, an extra sanity check should be implemented in the calibration function on any board using this calibration format.  