### PR TITLE
Temp board: Watchdog trigger when ADS1120 fails to initialise

### DIFF
--- a/STM32/Temperature/Core/Inc/Temperature.h
+++ b/STM32/Temperature/Core/Inc/Temperature.h
@@ -13,4 +13,4 @@ void initSensorCalibration();
 void setSensorCalibration(int pinNumber, char type);
 bool isCalibrationInputValid(const char *inputBuffer);
 void InitTemperature(SPI_HandleTypeDef* hspi_);
-void LoopTemperature();
+int LoopTemperature();

--- a/STM32/Temperature/Core/Src/Temperature.c
+++ b/STM32/Temperature/Core/Src/Temperature.c
@@ -155,6 +155,12 @@ int LoopTemperature(const char* bootMsg)
                 USBnprintf("Failed to initialise ADS1120 device %X. This SW require PCB version >= 5.2", spiErr);
             }
         }
+        else
+        {
+        	// Return non-fault state as long as COM port has not been opened
+        	// to ensure WatchDog does not trigger.
+        	return 0;
+        }
     }
 
     if (!isComPortOpen())

--- a/STM32/Temperature/Core/Src/Temperature.c
+++ b/STM32/Temperature/Core/Src/Temperature.c
@@ -100,7 +100,7 @@ void InitTemperature(SPI_HandleTypeDef* hspi_)
     hspi = hspi_;
 }
 
-void LoopTemperature(const char* bootMsg)
+int LoopTemperature(const char* bootMsg)
 {
     static int spiErr = 1;
     static uint32_t timeStamp = 0;
@@ -122,7 +122,7 @@ void LoopTemperature(const char* bootMsg)
 
         if (isComPortOpen())
         {
-            if (isFirstWrite)
+            if (isFirstWrite || spiErr)
             {
                 if (hspi != NULL)
                     spiErr = initSpiDevices(hspi);
@@ -130,8 +130,8 @@ void LoopTemperature(const char* bootMsg)
             }
 
             if (hspi == NULL) {
-                USBnprintf("This Temperature SW require PCB version >= 5.2 where SPI devices is attached");
-                return;
+                USBnprintf("This Temperature SW require PCB version >= 5.2 where SPI devices are attached");
+                return spiErr;
             }
 
             if (!spiErr)
@@ -153,8 +153,6 @@ void LoopTemperature(const char* bootMsg)
             else
             {
                 USBnprintf("Failed to initialise ADS1120 device %X. This SW require PCB version >= 5.2", spiErr);
-                USBnprintf("Re-initialising ADS1120 device");
-                spiErr = initSpiDevices(hspi);
             }
         }
     }
@@ -163,6 +161,7 @@ void LoopTemperature(const char* bootMsg)
     {
         isFirstWrite=true;
     }
+    return spiErr;
 }
 
 bool isCalibrationInputValid(const char *inputBuffer)

--- a/STM32/Temperature/Core/Src/main.c
+++ b/STM32/Temperature/Core/Src/main.c
@@ -105,6 +105,8 @@ int main(void)
   /* USER CODE BEGIN WHILE */
   while (1)
   {
+	  // Update the watchdog if the SPI communication to the
+	  // ADS1120 chips work as expected.
       if (!spiErr)
     	  HAL_WWDG_Refresh(&hwwdg);
       spiErr = LoopTemperature(bootMsg);

--- a/STM32/Temperature/Core/Src/main.c
+++ b/STM32/Temperature/Core/Src/main.c
@@ -108,7 +108,9 @@ int main(void)
 	  // Update the watchdog if the SPI communication to the
 	  // ADS1120 chips work as expected.
       if (!spiErr)
+      {
     	  HAL_WWDG_Refresh(&hwwdg);
+      }
       spiErr = LoopTemperature(bootMsg);
     /* USER CODE END WHILE */
 

--- a/STM32/Temperature/Core/Src/main.c
+++ b/STM32/Temperature/Core/Src/main.c
@@ -98,14 +98,16 @@ int main(void)
   MX_WWDG_Init();
   /* USER CODE BEGIN 2 */
   InitTemperature(&hspi1);
+  int spiErr = 0;
   /* USER CODE END 2 */
 
   /* Infinite loop */
   /* USER CODE BEGIN WHILE */
   while (1)
   {
-      HAL_WWDG_Refresh(&hwwdg);
-      LoopTemperature(bootMsg);
+      if (!spiErr)
+    	  HAL_WWDG_Refresh(&hwwdg);
+      spiErr = LoopTemperature(bootMsg);
     /* USER CODE END WHILE */
 
     /* USER CODE BEGIN 3 */


### PR DESCRIPTION
The temperature board sometimes fails to initialise the ADS1120 chips. 

This updates keeps trying to initialise the chip if the initialization fails. If the initialization keeps failing the watchdog triggers to force a full software reset of the board. 