### PR TITLE
MCP4725: Add library

### DIFF
--- a/STM32/Libraries/I2C/Inc/MCP4725.h
+++ b/STM32/Libraries/I2C/Inc/MCP4725.h
@@ -1,0 +1,32 @@
+/*
+ * MCP4725.h
+ *
+ *  Created on: Jun 22, 2022
+ *      Author: matias
+ */
+
+#ifndef INC_MCP4725_H_
+#define INC_MCP4725_H_
+
+#include "stm32f4xx_hal.h"
+#include "MCP4725.h"
+#include <stdbool.h>
+
+// Constant
+#define MCP4725_RES        4095
+
+// page 22
+#define MCP4725_GC_RESET        0x06
+#define MCP4725_GC_WAKEUP       0x09
+
+
+typedef struct {
+	I2C_HandleTypeDef *i2c_handle;
+	uint16_t device_address;
+} MCP4725_handle;
+
+bool MCP4725_init(MCP4725_handle *handle, I2C_HandleTypeDef * hi2c);
+HAL_StatusTypeDef MCP4725_getValue(MCP4725_handle *handle, uint16_t *value);
+HAL_StatusTypeDef MCP4725_setValue(MCP4725_handle *handle, uint16_t value);
+
+#endif /* INC_MCP4725_H_ */

--- a/STM32/Libraries/I2C/Inc/honeywellZephyrI2C.h
+++ b/STM32/Libraries/I2C/Inc/honeywellZephyrI2C.h
@@ -1,0 +1,13 @@
+#pragma once
+
+/*
+ * Description:
+ * Provides an interface to communicate with the honeywell zephyr air flow sensor.
+ */
+#include "stm32f4xx_hal.h"
+
+// Get sensor serial number
+HAL_StatusTypeDef honeywellZephyrSerial(I2C_HandleTypeDef* hi2c, uint32_t *serialNB);
+
+// read measured value.
+HAL_StatusTypeDef honeywellZephyrRead(I2C_HandleTypeDef *hi2c, float *flowData);

--- a/STM32/Libraries/I2C/Inc/sht35.h
+++ b/STM32/Libraries/I2C/Inc/sht35.h
@@ -1,0 +1,43 @@
+/*
+ * sht35.h
+ *
+ *  Created on: Apr 15, 2021
+ *      Author: alexander.mizrahi@copenhagenAtomics.com
+ */
+#pragma once
+#ifndef INC_SHT35_H_
+#define INC_SHT35_H_
+
+
+
+#endif /* INC_SHT35_H_ */
+#include "stm32f4xx_hal.h"
+
+#include <stdbool.h>
+#include "assert.h"
+#include "string.h"
+
+
+typedef struct {
+	I2C_HandleTypeDef *i2c_handle;
+	uint16_t device_address;
+} sht3x_handle_t;
+
+typedef enum
+{
+	SHT3X_COMMAND_MEASURE_HIGHREP_STRETCH = 0x2c06,
+	SHT3X_COMMAND_CLEAR_STATUS = 0x3041,
+	SHT3X_COMMAND_SOFT_RESET = 0x30A2,
+	SHT3X_COMMAND_HEATER_ENABLE = 0x306d,
+	SHT3X_COMMAND_HEATER_DISABLE = 0x3066,
+	SHT3X_COMMAND_READ_STATUS = 0xf32d,
+	SHT3X_COMMAND_FETCH_DATA = 0xe000,
+	SHT3X_COMMAND_MEASURE_HIGHREP_10HZ = 0x2737,
+	SHT3X_COMMAND_MEASURE_LOWREP_10HZ = 0x272a
+} sht3x_command_t;
+
+HAL_StatusTypeDef sht3x_send_command(sht3x_handle_t *handle, sht3x_command_t command);
+HAL_StatusTypeDef sht3x_init(sht3x_handle_t *handle);
+HAL_StatusTypeDef sht3x_read_temperature_and_humidity(sht3x_handle_t *handle, float *temperature, float *humidity);
+
+

--- a/STM32/Libraries/I2C/Inc/si7051.h
+++ b/STM32/Libraries/I2C/Inc/si7051.h
@@ -1,0 +1,15 @@
+/*
+ * si7051.h
+ *
+ *  Created on: Jul 26, 2021
+ *      Author: alema
+ */
+
+#ifndef INC_SI7051_H_
+#define INC_SI7051_H_
+
+#include "stm32f4xx_hal.h"
+HAL_StatusTypeDef si7051Temp(I2C_HandleTypeDef *hi2c1, float* siValue);
+
+#endif /* INC_SI7051_H_ */
+

--- a/STM32/Libraries/I2C/Src/MCP4725.c
+++ b/STM32/Libraries/I2C/Src/MCP4725.c
@@ -6,7 +6,6 @@
  */
 
 #include "MCP4725.h"
-#include "main.h"
 #include <assert.h>
 #include <stdbool.h>
 

--- a/STM32/Libraries/I2C/Src/MCP4725.c
+++ b/STM32/Libraries/I2C/Src/MCP4725.c
@@ -1,0 +1,60 @@
+/*
+ * MCP4725.c
+ *
+ *  Created on: Jun 22, 2022
+ *      Author: matias
+ */
+
+#include "MCP4725.h"
+#include "main.h"
+#include <assert.h>
+#include <stdbool.h>
+
+
+static uint16_t uint8Merge(uint8_t msb, uint8_t lsb){
+	return (uint16_t)((uint16_t) msb << 8u) | lsb;
+}
+
+bool MCP4725_init(MCP4725_handle *handle, I2C_HandleTypeDef * hi2c)
+{
+	bool i2cErr = false;
+	handle->i2c_handle = hi2c;
+	HAL_StatusTypeDef ret = MCP4725_setValue(handle, 0);
+
+	if (ret != HAL_OK)
+	{
+    	i2cErr = true;
+	}
+	return i2cErr;
+}
+
+HAL_StatusTypeDef MCP4725_setValue(MCP4725_handle *handle, uint16_t value)
+{
+	if (handle->i2c_handle == NULL)
+		return HAL_ERROR;
+
+	if (value > MCP4725_RES || value < 0)
+		return HAL_ERROR;
+
+	uint8_t command[2] = {(value & 0xff00) >> 8u, value & 0x00ff};
+	HAL_StatusTypeDef ret = HAL_I2C_Master_Transmit(handle->i2c_handle, handle->device_address << 1u, command, sizeof(command), 10);
+
+	return ret;
+}
+
+
+HAL_StatusTypeDef MCP4725_getValue(MCP4725_handle *handle, uint16_t *value)
+{
+	if (handle->i2c_handle == NULL)
+		return HAL_ERROR;
+
+	uint8_t buffer[5];
+
+	HAL_StatusTypeDef ret = HAL_I2C_Master_Receive(handle->i2c_handle, (handle->device_address  << 1u) | 0x01, buffer, sizeof(buffer), 10);
+	if (ret != HAL_OK)
+		return ret;
+
+	*value = (uint8Merge(buffer[1], buffer[2]) >> 4);
+	return HAL_OK;
+}
+

--- a/STM32/Libraries/I2C/Src/honeywellZephyrI2C.c
+++ b/STM32/Libraries/I2C/Src/honeywellZephyrI2C.c
@@ -1,0 +1,59 @@
+/* Description:
+ * Provides an interface to communicate with the honeywell zephyr air flow sensor. */
+
+#include "stm32f4xx_hal.h"
+#include "honeywellZephyrI2C.h"
+
+#define ZephyrADDR 0x49
+HAL_StatusTypeDef honeywellZephyrRead(I2C_HandleTypeDef *hi2c, float *flowData)
+{
+    uint8_t readSensorADDR = 0x00;
+
+    uint8_t addata[2];
+    HAL_StatusTypeDef ret;
+    ret = HAL_I2C_Master_Transmit(hi2c, (uint16_t) (ZephyrADDR << 1), &readSensorADDR, 2, 50);
+    if (ret != HAL_OK)
+        return ret;
+
+    ret = HAL_I2C_Master_Receive(hi2c, (uint16_t) (ZephyrADDR << 1) | 0x01, addata, 2, 50);
+    if (ret != HAL_OK)
+        return ret;
+
+    const uint16_t lowLimit = 1638 + 16380/200; // 0 + 0.5% of Full Scale.
+    uint16_t uFlow = ((uint16_t) addata[0] << 8) | addata[1];
+    if (uFlow <= lowLimit)      *flowData = 0; // Lower limit 0%
+    else if (uFlow >= 14746)    *flowData = 1; // Full scale output 100%
+    else                        *flowData = ((uFlow / 16384.0) - 0.1) / 0.8;
+
+    return HAL_OK;
+}
+
+HAL_StatusTypeDef honeywellZephyrSerial(I2C_HandleTypeDef *hi2c, uint32_t *serialNB)
+{
+    uint8_t readSerialNBADDR = 0x01;
+    *serialNB = 0;
+
+    // The sensor prints out 2 bytes on startup with its serial number
+    uint8_t addata1[4];
+    HAL_StatusTypeDef ret;
+    ret = HAL_I2C_Master_Transmit(hi2c, (uint16_t) (ZephyrADDR << 1), &readSerialNBADDR, 1, 50);
+    if (ret != HAL_OK)
+        return ret;
+
+    HAL_Delay(2);
+    ret = HAL_I2C_Master_Receive(hi2c, (uint16_t) (ZephyrADDR << 1) | 0x01, &addata1[0], 2, 50);
+    if (ret != HAL_OK)
+        return ret;
+
+    HAL_Delay(10);
+    ret = HAL_I2C_Master_Receive(hi2c, (uint16_t) (ZephyrADDR << 1) | 0x01, &addata1[2], 2, 50);
+    if (ret != HAL_OK)
+        return ret;
+
+    *serialNB = ((addata1[0] & 0xFF) << 24)
+              | ((addata1[1] & 0xFF) << 16)
+              | ((addata1[2] & 0xFF) << 8)
+              |   addata1[3];
+
+    return ret;
+}

--- a/STM32/Libraries/I2C/Src/sht35.c
+++ b/STM32/Libraries/I2C/Src/sht35.c
@@ -1,0 +1,95 @@
+/*
+ * sht35.c
+ *
+ *  Created on: Apr 15, 2021
+ *      Author: alexander.mizrahi@copenhagenAtomics.com
+ */
+
+#include "sht35.h"
+#include <assert.h>
+
+HAL_StatusTypeDef ret;
+
+
+
+static uint8_t calculate_crc(const uint8_t *data, size_t length){
+	uint8_t crc = 0xff;
+	for (size_t i = 0; i < length; i++) {
+		crc ^= data[i];
+		for (size_t j = 0; j < 8; j++) {
+			if ((crc & 0x80u) != 0) {
+				crc = (uint8_t)((uint8_t)(crc << 1u) ^ 0x31u);
+			} else {
+				crc <<= 1u;
+			}
+		}
+	}
+	return crc;
+}
+
+HAL_StatusTypeDef sht3x_send_command(sht3x_handle_t *handle, sht3x_command_t command){
+	//divides the uint16_t command variable into two uint8_t variables
+	uint8_t command_buffer[2] = {(command & 0xff00u) >> 8u, command & 0xffu};
+
+
+	ret = HAL_I2C_Master_Transmit(handle->i2c_handle, handle->device_address << 1u, command_buffer, sizeof(command_buffer), 50);
+		if(ret != HAL_OK){
+		return ret;
+	}
+
+	return HAL_OK;
+}
+
+static uint16_t uint8Merge(uint8_t msb, uint8_t lsb){
+	return (uint16_t)((uint16_t)msb << 8u) | lsb;
+}
+
+HAL_StatusTypeDef sht3x_init(sht3x_handle_t *handle){
+
+	assert(handle->i2c_handle->Init.NoStretchMode == I2C_NOSTRETCH_DISABLE);
+	// TODO: Assert i2c frequency is not too high
+
+	uint8_t status_reg_and_checksum[3];
+	ret = HAL_I2C_Mem_Read(handle->i2c_handle, handle->device_address << 1u, SHT3X_COMMAND_READ_STATUS, 2, (uint8_t*)&status_reg_and_checksum,
+					  sizeof(status_reg_and_checksum), 50);
+	if (ret != HAL_OK) {
+		return ret;
+	}
+
+	uint8_t calculated_crc = calculate_crc(status_reg_and_checksum, 2);
+
+	if (calculated_crc != status_reg_and_checksum[2]) {
+		return HAL_ERROR;
+	}
+
+	return HAL_OK;
+}
+
+HAL_StatusTypeDef sht3x_read_temperature_and_humidity(sht3x_handle_t *handle, float *temperature, float *humidity){
+	sht3x_send_command(handle, SHT3X_COMMAND_MEASURE_HIGHREP_STRETCH);
+
+	HAL_Delay(1);
+
+	uint8_t buffer[6];
+	ret = HAL_I2C_Master_Receive(handle->i2c_handle, handle->device_address << 1u, buffer, sizeof(buffer), 50);
+	if(ret != HAL_OK) {
+		return ret;
+	}
+
+	//checks if data is correct using CRC
+	uint8_t temperature_crc = calculate_crc(buffer, 2);
+	uint8_t humidity_crc = calculate_crc(buffer + 3, 2);
+	if (temperature_crc != buffer[2] || humidity_crc != buffer[5]) {
+		return HAL_ERROR;
+	}
+
+	//merges data into a uint16
+	int16_t temperature_raw = (int16_t)uint8Merge(buffer[0], buffer[1]);
+	uint16_t humidity_raw = uint8Merge(buffer[3], buffer[4]);
+
+	//processes data
+	*temperature = -45.0f + 175.0f * (float)temperature_raw / 65535.0f;
+	*humidity = 100.0f * (float)humidity_raw / 65535.0f;
+
+	return HAL_OK;
+}

--- a/STM32/Libraries/I2C/Src/si7051.c
+++ b/STM32/Libraries/I2C/Src/si7051.c
@@ -1,0 +1,33 @@
+/*
+ * si7051.c
+ *
+ *  Created on: Jul 26, 2021
+ *      Author: alema
+ */
+
+#include "si7051.h"
+
+#define SI7051_I2C_ADDR          0x40
+#define SI7051_TEMPERATUR_OFFSET 0xF3
+
+HAL_StatusTypeDef si7051Temp(I2C_HandleTypeDef *hi2c1, float* siValue)
+{
+    uint8_t readSensorADDR = SI7051_TEMPERATUR_OFFSET;
+
+    // Poll I2C device
+    HAL_StatusTypeDef  ret = HAL_I2C_Master_Transmit(hi2c1, (uint16_t)(SI7051_I2C_ADDR << 1), &readSensorADDR, 1, 50);
+    if (HAL_OK == ret)
+    {
+        HAL_Delay(10); //delay is needed for response time
+
+        uint8_t addata[2];
+        ret = HAL_I2C_Master_Receive(hi2c1, (SI7051_I2C_ADDR << 1) | 0x01, addata, 2, 50);
+        if (HAL_OK == ret)
+        {
+            uint16_t si7051_temp = addata[0] << 8 | addata[1];
+            *siValue = (175.72*si7051_temp) / 65536 - 46.85;
+        }
+    }
+
+    return ret;
+}


### PR DESCRIPTION
Interface to MCP4725 DAC component. 

EDIT: All I2C library functions have now been collected in one repo (Like the SPI libraries.) The previous structure will  be deleted as projects using the old folder structure are updated to the new one.