### PR TITLE
Temperature: Allow one or more ADS1120 chips to be unreachable

### DIFF
--- a/STM32/Libraries/SPI/Inc/ADS1120.h
+++ b/STM32/Libraries/SPI/Inc/ADS1120.h
@@ -9,7 +9,7 @@ typedef enum
     INPUT_TEMP,      // config for temperature reading.
     INPUT_CHA,       // config for first input
     INPUT_CHB,       // config for second input
-    INPUT_CALIBREATE // calibration, measure (AVDD-AVSS)/2.
+    INPUT_CALIBRATE // calibration, measure (AVDD-AVSS)/2.
 } ADS1120_input;
 
 typedef struct ADS1120Data {

--- a/STM32/Libraries/SPI/Src/ADS1120.c
+++ b/STM32/Libraries/SPI/Src/ADS1120.c
@@ -66,7 +66,7 @@ static ADS1120_input nextInput(ADS1120_input current)
     case INPUT_TEMP:       return INPUT_CHA;
     case INPUT_CHA:        return INPUT_CHB;
     case INPUT_CHB:        return INPUT_CALIBRATE;
-    case INPUT_CALIBRATE: return INPUT_TEMP;
+    case INPUT_CALIBRATE:  return INPUT_TEMP;
     }
 
     // Make compiler happy. If no return a warning from compiler is issued.

--- a/STM32/Libraries/SPI/Src/ADS1120.c
+++ b/STM32/Libraries/SPI/Src/ADS1120.c
@@ -65,12 +65,12 @@ static ADS1120_input nextInput(ADS1120_input current)
     {
     case INPUT_TEMP:       return INPUT_CHA;
     case INPUT_CHA:        return INPUT_CHB;
-    case INPUT_CHB:        return INPUT_CALIBREATE;
-    case INPUT_CALIBREATE: return INPUT_TEMP;
+    case INPUT_CHB:        return INPUT_CALIBRATE;
+    case INPUT_CALIBRATE: return INPUT_TEMP;
     }
 
     // Make compiler happy. If no return a warning from compiler is issued.
-    return INPUT_CALIBREATE;
+    return INPUT_CALIBRATE;
 }
 
 
@@ -192,7 +192,7 @@ static int setInput(ADS1120Device *dev, ADS1120_input selectedInput, bool verify
     case INPUT_CHB:
         cfg.mux = 5;
         break;
-    case INPUT_CALIBREATE:
+    case INPUT_CALIBRATE:
         cfg.mux = 0x0E;
         break;
     }
@@ -234,16 +234,16 @@ int ADS1120Init(ADS1120Device *dev)
     stmSetGpio(dev->cs, false);
     if (reset(dev) != HAL_OK)
     {
-        ret = -1;
+        ret = 1;
     }
     else
     {
         HAL_Delay(1); // wait 50µs+32*t(CLK) < 1mSec after reset
 
         // Check that the configuration can be set.
-        ret = setInput(dev, INPUT_CALIBREATE, true);
+        ret = setInput(dev, INPUT_CALIBRATE, true);
         if (ret != 0) {
-            ret = -2;
+            ret = 2;
         }
     }
 
@@ -263,7 +263,7 @@ void ADS1120Loop(ADS1120Device *dev, float *type_calibration)
     {
         // Something is wrong. Restart from calibrate
         stmSetGpio(dev->cs, false);
-        setInput(dev, INPUT_CALIBREATE, false);
+        setInput(dev, INPUT_CALIBRATE, false);
         ADCSync(dev); // If no change in SPI flags a new ADC acquire is not started.
         stmSetGpio(dev->cs, true);
 
@@ -284,7 +284,7 @@ void ADS1120Loop(ADS1120Device *dev, float *type_calibration)
     if (readADC(dev, &adcValue) != HAL_OK)
     {
         // Something is wrong. Restart from calibrate
-        setInput(dev, INPUT_CALIBREATE, false);
+        setInput(dev, INPUT_CALIBRATE, false);
         ADCSync(dev); // If no change in SPI flags a new ADC acquire is not started.
     }
     else
@@ -304,7 +304,7 @@ void ADS1120Loop(ADS1120Device *dev, float *type_calibration)
             data->chB = adc2Temp(((int16_t) adcValue), data->calibration, data->internalTemp, *(type_calibration+2), *(type_calibration + 3));
             break;
 
-        case INPUT_CALIBREATE:
+        case INPUT_CALIBRATE:
             // The offset value from ADC1120 can be either negative or positive.
             data->calibration += (((int16_t) adcValue) - data->calibration) / mAvgTime;
             break;

--- a/STM32/Temperature/Core/Inc/Temperature.h
+++ b/STM32/Temperature/Core/Inc/Temperature.h
@@ -13,4 +13,4 @@ void initSensorCalibration();
 void setSensorCalibration(int pinNumber, char type);
 bool isCalibrationInputValid(const char *inputBuffer);
 void InitTemperature(SPI_HandleTypeDef* hspi_);
-int LoopTemperature();
+void LoopTemperature();

--- a/STM32/Temperature/Core/Src/Temperature.c
+++ b/STM32/Temperature/Core/Src/Temperature.c
@@ -129,8 +129,8 @@ void LoopTemperature(const char* bootMsg)
     {
         timeStamp = HAL_GetTick();
 
-       // if (isComPortOpen())
-        //{
+        if (isComPortOpen())
+        {
             if (isFirstWrite)
             {
                 if (hspi != NULL)
@@ -163,7 +163,7 @@ void LoopTemperature(const char* bootMsg)
 					, ads1120[3].data.chA, ads1120[3].data.chB
 					, ads1120[4].data.chA, ads1120[4].data.chB
 					, internalTemp);
-        //}
+        }
     }
 
     //if (!isComPortOpen())

--- a/STM32/Temperature/Core/Src/Temperature.c
+++ b/STM32/Temperature/Core/Src/Temperature.c
@@ -166,8 +166,8 @@ void LoopTemperature(const char* bootMsg)
         }
     }
 
-    //if (!isComPortOpen())
-    //    isFirstWrite=true;
+    if (!isComPortOpen())
+        isFirstWrite=true;
 }
 
 bool isCalibrationInputValid(const char *inputBuffer)

--- a/STM32/Temperature/Core/Src/Temperature.c
+++ b/STM32/Temperature/Core/Src/Temperature.c
@@ -129,8 +129,8 @@ void LoopTemperature(const char* bootMsg)
     {
         timeStamp = HAL_GetTick();
 
-        if (isComPortOpen())
-        {
+       // if (isComPortOpen())
+        //{
             if (isFirstWrite)
             {
                 if (hspi != NULL)
@@ -163,11 +163,11 @@ void LoopTemperature(const char* bootMsg)
 					, ads1120[3].data.chA, ads1120[3].data.chB
 					, ads1120[4].data.chA, ads1120[4].data.chB
 					, internalTemp);
-        }
+        //}
     }
 
-    if (!isComPortOpen())
-        isFirstWrite=true;
+    //if (!isComPortOpen())
+    //    isFirstWrite=true;
 }
 
 bool isCalibrationInputValid(const char *inputBuffer)

--- a/STM32/Temperature/Core/Src/main.c
+++ b/STM32/Temperature/Core/Src/main.c
@@ -98,7 +98,6 @@ int main(void)
   MX_WWDG_Init();
   /* USER CODE BEGIN 2 */
   InitTemperature(&hspi1);
-  int spiErr = 0;
   /* USER CODE END 2 */
 
   /* Infinite loop */
@@ -107,11 +106,8 @@ int main(void)
   {
 	  // Update the watchdog if the SPI communication to the
 	  // ADS1120 chips work as expected.
-      if (!spiErr)
-      {
-    	  HAL_WWDG_Refresh(&hwwdg);
-      }
-      spiErr = LoopTemperature(bootMsg);
+	  HAL_WWDG_Refresh(&hwwdg);
+      LoopTemperature(bootMsg);
     /* USER CODE END WHILE */
 
     /* USER CODE BEGIN 3 */


### PR DESCRIPTION
When an ADS1120 chip is unreachable i.e. from bad soldering of STM32 chip on PCB the unreachable chip is simply ignored, but the rest of the ports are still being measured on.

The error code "**10010**" is used as an indication that an ADS1120 is not reachable and the two physical ports are therefore unavailable. 

This also means that the watchdog no longer triggers because of poorly initialised peripherals. The watchdog is will still trigger in case of a halt in the process.   