### PR TITLE
AirConCtrl: Repeat command to lower risk of unreceived message

### DIFF
--- a/STM32/AirconCtrl/Core/Inc/transmitterIR.h
+++ b/STM32/AirconCtrl/Core/Inc/transmitterIR.h
@@ -50,6 +50,7 @@
 #define LOW_BIT_ARR		7042 	// Period of 880us (~1136Hz)
 #define LOW_BIT_CCR		4296    // On time (61%)
 
+#define NO_COMMAND_REPEATS 5
 
 void getACStates(int * tempState);
 void updateTemperatureIR(int temp);


### PR DESCRIPTION
The air conditioning controller can send a command to update the state of the air condition system.

However, given there is no feedback to the controller of whether the receiver has properly received the command there is a risk of miscommunication.
As a workaround when sending a command, the command is repeated 5 times to minimize the risk of a lost message. 