### PR TITLE
LightController: Add light controller to OTP boardtypes

### DIFF
--- a/STM32/Libraries/Util/Inc/systemInfo.h
+++ b/STM32/Libraries/Util/Inc/systemInfo.h
@@ -16,7 +16,8 @@ typedef enum {
 	ZrO2Oxygen 		= 11,
 	AMBcurrent 		= 12,
 	Geiger 			= 13,
-	AirCondition 	= 14
+	AirCondition 	= 14,
+	LightController = 15
 } BoardType;
 typedef uint8_t SubBoardType; // SubBoardType needed for some boards.
 


### PR DESCRIPTION
The light controller board is added to the list of valid board types in the OTP library.