### PR TITLE
Library: Flash read/write using CRC32 for data integrity 

### DIFF
--- a/STM32/Libraries/FLASH_readwrite/Inc/FLASH_readwrite.h
+++ b/STM32/Libraries/FLASH_readwrite/Inc/FLASH_readwrite.h
@@ -8,9 +8,16 @@ Description:		Provides an interface to read and write FLASH memory.
 #define INC_FLASH_READWRITE_H_
 
 #include <stdint.h>
+#ifdef HAL_CRC_MODULE_ENABLED
+  #include "stm32f4xx_hal_crc.h"
+#endif
 
-void writeToFlash(uint32_t indx, uint32_t size, uint8_t *dataToBeSaved);
-void readFromFlash(uint32_t indx, uint32_t size, uint8_t *dataToBeRead);
+void writeToFlash(uint32_t indx, uint32_t size, uint8_t *data);
+void readFromFlash(uint32_t indx, uint32_t size, uint8_t *data);
 
+#ifdef HAL_CRC_MODULE_ENABLED
+	void writeToFlashSafe(CRC_HandleTypeDef *hcrc, uint32_t indx, uint32_t size, uint8_t *data);
+	void readFromFlashSafe(CRC_HandleTypeDef *hcrc, uint32_t indx, uint32_t size, uint8_t *data);
+#endif
 #endif /* INC_FLASH_READWRITE_H_ */
 

--- a/STM32/Libraries/FLASH_readwrite/Src/FLASH_readwrite.c
+++ b/STM32/Libraries/FLASH_readwrite/Src/FLASH_readwrite.c
@@ -102,8 +102,6 @@ void writeToFlashSafe(CRC_HandleTypeDef *hcrc, uint32_t indx, uint32_t size, uin
 // is not enabled in project.
 void readFromFlashSafe(CRC_HandleTypeDef *hcrc, uint32_t indx, uint32_t size, uint8_t *data)
 {
-    __HAL_RCC_WWDG_CLK_DISABLE();
-
     // Read data including CRC value
     for(uint32_t i=0; i<size; i++)
     {
@@ -122,7 +120,5 @@ void readFromFlashSafe(CRC_HandleTypeDef *hcrc, uint32_t indx, uint32_t size, ui
     // default values are loaded and stored in boards.
     if (crcStored != crcVal)
     	*data = 0xFF;
-
-    __HAL_RCC_WWDG_CLK_ENABLE();
 }
 #endif

--- a/STM32/Libraries/FLASH_readwrite/Src/FLASH_readwrite.c
+++ b/STM32/Libraries/FLASH_readwrite/Src/FLASH_readwrite.c
@@ -6,8 +6,9 @@
  *        to read/write the flash. So flash layout should be defined.
 */
 
-#include <FLASH_readwrite.h>
 #include <stm32f4xx_hal.h>
+#include <FLASH_readwrite.h>
+#include <string.h>
 
 // NOTE: The flash sector and addr variables originate from the ld linker script.
 // The flash is used for program data and this must NOT be cleared. Putting data in
@@ -18,9 +19,12 @@ extern uint32_t _FlashAddr;   // Variable defined in ld linker script.
 #define FLASH_SECTOR ((uint32_t) &_FlashSector)
 #define FLASH_ADDR   ((uint32_t) &_FlashAddr)
 
-void writeToFlash(uint32_t indx, uint32_t size, uint8_t *dataToBeSaved)
+// Write data to FLASH_ADDR+indx directly. This method does not
+// ensure any data integrity as data validation is performed.
+void writeToFlash(uint32_t indx, uint32_t size, uint8_t *data)
 {
     __HAL_RCC_WWDG_CLK_DISABLE();
+
     // Erase the sector before write
     HAL_FLASH_Unlock();
     FLASH_Erase_Sector(FLASH_SECTOR, FLASH_VOLTAGE_RANGE_3);
@@ -28,18 +32,97 @@ void writeToFlash(uint32_t indx, uint32_t size, uint8_t *dataToBeSaved)
 
     // Write to sector
     HAL_FLASH_Unlock();
+
     for(uint32_t i=0; i<size; i++)
     {
-        HAL_FLASH_Program(FLASH_TYPEPROGRAM_BYTE, FLASH_ADDR+indx+i , dataToBeSaved[i]);
+        HAL_FLASH_Program(FLASH_TYPEPROGRAM_BYTE, FLASH_ADDR+indx+i , data[i]);
     }
     HAL_FLASH_Lock();
     __HAL_RCC_WWDG_CLK_ENABLE();
 }
 
-void readFromFlash(uint32_t indx, uint32_t size, uint8_t *dataToBeRead)
+// Read from flash without checking data integrity if CRC module
+// is not enabled in project.
+void readFromFlash(uint32_t indx, uint32_t size, uint8_t *data)
 {
     for(uint32_t i=0; i<size; i++)
     {
-        *(dataToBeRead + i) = *( (uint8_t *)(FLASH_ADDR+indx+i) );
+        *(data + i) = *( (uint8_t *)(FLASH_ADDR+indx+i) );
     }
 }
+
+
+// If this check is not included the compiler will throw an
+// error for projects where CRC module is not enabled
+#ifdef HAL_CRC_MODULE_ENABLED
+uint32_t computeCRC(CRC_HandleTypeDef *hcrc, uint32_t size, uint8_t *data)
+{
+    // Convert data to uint32_t as needed for the CRC computation
+	uint32_t crcData[size/sizeof(uint32_t)];
+    memcpy(&crcData, data, size);
+
+    // Compute CRC of stored data
+    uint32_t crcVal = HAL_CRC_Calculate(hcrc, crcData, sizeof(crcData)/sizeof(uint32_t));
+    return crcVal;
+}
+
+// Write data to FLASH_ADDR+indx including CRC.
+void writeToFlashSafe(CRC_HandleTypeDef *hcrc, uint32_t indx, uint32_t size, uint8_t *data)
+{
+    __HAL_RCC_WWDG_CLK_DISABLE();
+
+    // Erase the sector before write
+    HAL_FLASH_Unlock();
+    FLASH_Erase_Sector(FLASH_SECTOR, FLASH_VOLTAGE_RANGE_3);
+    HAL_FLASH_Lock();
+
+    // Compute CRC of data to be saved.
+    uint32_t crcVal = computeCRC(hcrc, size, data);
+
+	// Append CRC converted to uint8_t to data
+	for (uint8_t i = 0; i < 4; i++)
+	{
+		uint8_t convertedCrcTemp = (crcVal >> 8*i) & 0xFF;
+		*(data + size + i) = convertedCrcTemp;
+	}
+	uint32_t saveSize = size + sizeof(uint32_t);
+
+    // Write to sector
+    HAL_FLASH_Unlock();
+    for(uint32_t i=0; i<saveSize; i++)
+    {
+        HAL_FLASH_Program(FLASH_TYPEPROGRAM_BYTE, FLASH_ADDR+indx+i , data[i]);
+    }
+    HAL_FLASH_Lock();
+    __HAL_RCC_WWDG_CLK_ENABLE();
+}
+
+
+// Read from flash without checking data integrity if CRC module
+// is not enabled in project.
+void readFromFlashSafe(CRC_HandleTypeDef *hcrc, uint32_t indx, uint32_t size, uint8_t *data)
+{
+    __HAL_RCC_WWDG_CLK_DISABLE();
+
+    // Read data including CRC value
+    for(uint32_t i=0; i<size; i++)
+    {
+        *(data + i) = *( (uint8_t *)(FLASH_ADDR+indx+i) );
+    }
+
+    // Compute CRC of data read.
+    uint32_t crcVal = computeCRC(hcrc, size, data);
+
+    // Retrieve stored CRC value in flash.
+    uint32_t crcStored = 0;
+    memcpy(&crcStored, (uint8_t *)(FLASH_ADDR+indx+size), sizeof(uint32_t));
+
+    // If computed and stored CRC value does not match
+    // set data[0]=0xFF which resembles a clean FLASH i.e.
+    // default values are loaded and stored in boards.
+    if (crcStored != crcVal)
+    	*data = 0xFF;
+
+    __HAL_RCC_WWDG_CLK_ENABLE();
+}
+#endif

--- a/STM32/Libraries/FLASH_readwrite/Src/FLASH_readwrite.c
+++ b/STM32/Libraries/FLASH_readwrite/Src/FLASH_readwrite.c
@@ -75,6 +75,7 @@ void writeToFlashSafe(CRC_HandleTypeDef *hcrc, uint32_t indx, uint32_t size, uin
     HAL_FLASH_Unlock();
     FLASH_Erase_Sector(FLASH_SECTOR, FLASH_VOLTAGE_RANGE_3);
     HAL_FLASH_Lock();
+    __HAL_RCC_WWDG_CLK_ENABLE();
 
     // Compute CRC of data to be saved.
     uint32_t crcVal = computeCRC(hcrc, size, data);
@@ -87,6 +88,7 @@ void writeToFlashSafe(CRC_HandleTypeDef *hcrc, uint32_t indx, uint32_t size, uin
 	}
 	uint32_t saveSize = size + sizeof(uint32_t);
 
+	__HAL_RCC_WWDG_CLK_DISABLE();
     // Write to sector
     HAL_FLASH_Unlock();
     for(uint32_t i=0; i<saveSize; i++)


### PR DESCRIPTION
The FLASH read/write library has been updated to include 'safe' versions of the data storing/retrieving.

The #ifdef clauses ensure that the built-in CRC module of the STM32F401 MCU has been enabled, since a project will not have access to the CRC handle, HAL_CRC_Calculate function as well as the stm32f4xx_hal_crc.h file otherwise. 

Note: The data stored in using the built in FLASH functions take uint8_t data type as input, whereas the CRC32 module only accepts uint32_t. Hence, memcpy calls are necessary since a simple conversion between uint8_t and uint32_t violates the [strict aliasing rule](https://stackoverflow.com/questions/98650/what-is-the-strict-aliasing-rule) i.e. please pay extra attention to those calls to ensure the code can not go into any unwanted/unexpected behavior. 

The boards will be updated afterwards to include the CRC module and the legacy functions may be removed after all boards using FLASH functionality has been updated and call the update 'safe' functions. 