### PR TITLE
AC: Overheat prevention.

### DIFF
--- a/STM32/AC/Core/Src/ACBoard.c
+++ b/STM32/AC/Core/Src/ACBoard.c
@@ -213,8 +213,10 @@ static void heatSinkLoop()
     {
     	unsigned long now = HAL_GetTick();
     	if (now - previous > 2000)	// 2000ms. Should be aligned with the control period of heater.
+    	{
+    		previous = now;
     		adjustPWMDown();
-    	previous = now;
+    	}
     }
 }
 

--- a/STM32/AC/Core/Src/ACBoard.c
+++ b/STM32/AC/Core/Src/ACBoard.c
@@ -184,8 +184,7 @@ static void CAallOn(bool isOn)
 }
 static void CAportState(int port, bool state, int percent, int duration)
 {
-	uint8_t pwmPercent;
-	getPWMPinPercent(port-1, &pwmPercent);
+	uint8_t pwmPercent = getPWMPinPercent(port-1);
 	// If heat sink has reached the maximum allowed temperature and user
 	// tries to heat the system further up then disregard the input command
 	if (heatSinkTemperature > MAX_TEMPERATURE && percent > pwmPercent)
@@ -198,12 +197,9 @@ static void heatSinkLoop()
 {
 	static unsigned long previous = 0;
     // Turn on fan if temp > 55 and turn of when temp < 50.
-    if (stmGetGpio(fanCtrl) && isFanAutoOn)
+    if (heatSinkTemperature < 50 && isFanAutoOn)
     {
-        if (heatSinkTemperature < 50)
-        {
-            stmSetGpio(fanCtrl, false);
-        }
+		stmSetGpio(fanCtrl, false);
     }
     else if (heatSinkTemperature > 55)
     {

--- a/STM32/AC/Core/Src/ACBoard.c
+++ b/STM32/AC/Core/Src/ACBoard.c
@@ -32,7 +32,7 @@ static struct
 } heaterPorts[4];
 static StmGpio fanCtrl;
 static double heatSinkTemperature = 0; // Heat Sink temperature
-static bool isFanAutoOn = true;
+static bool isFanForceOn = false;
 
 // Forward declare functions.
 static void CAallOn(bool isOn);
@@ -56,12 +56,12 @@ static void userInput(const char *input)
 {
 	if (strncmp(input, "fan on", 6) == 0)
 	{
-		isFanAutoOn = false;
+		isFanForceOn = true;
 		stmSetGpio(fanCtrl, true);
 	}
 	else if (strncmp(input, "fan off", 7) == 0)
 	{
-		isFanAutoOn = true;
+		isFanForceOn = false;
 		stmSetGpio(fanCtrl, false);
 	}
 }
@@ -197,7 +197,7 @@ static void heatSinkLoop()
 {
 	static unsigned long previous = 0;
     // Turn on fan if temp > 55 and turn of when temp < 50.
-    if (heatSinkTemperature < 50 && isFanAutoOn)
+    if (heatSinkTemperature < 50 && !isFanForceOn)
     {
 		stmSetGpio(fanCtrl, false);
     }

--- a/STM32/AC/Core/Src/ACBoard.c
+++ b/STM32/AC/Core/Src/ACBoard.c
@@ -211,9 +211,8 @@ static void heatSinkLoop()
     }
     else if (heatSinkTemperature > MAX_TEMPERATURE) // Safety mode to avoid overheating of the board
     {
-
     	unsigned long now = HAL_GetTick();
-    	if (now - previous > 2000)
+    	if (now - previous > 2000)	// 2000ms. Should be aligned with the control period of heater.
     		adjustPWMDown();
     	previous = now;
     }

--- a/STM32/AC/Core/Src/ACBoard.c
+++ b/STM32/AC/Core/Src/ACBoard.c
@@ -22,7 +22,7 @@
 #define ADC_CHANNELS	5
 #define ADC_CHANNEL_BUF_SIZE	400
 
-#define MAX_TEMPERATURE 80
+#define MAX_TEMPERATURE 70
 
 /* GPIO settings. */
 static struct

--- a/STM32/AC/HeatCtrl/Inc/HeatCtrl.h
+++ b/STM32/AC/HeatCtrl/Inc/HeatCtrl.h
@@ -16,3 +16,5 @@ void turnOffPin(int pin);
 void turnOnPin(int pin);
 void turnOnPinDuration(int pin, int duration);
 void setPWMPin(int pin, int pwmPct, int duration);
+void adjustPWMDown();
+void getPWMPinPercent(int pin, uint8_t *pwmPercent);

--- a/STM32/AC/HeatCtrl/Inc/HeatCtrl.h
+++ b/STM32/AC/HeatCtrl/Inc/HeatCtrl.h
@@ -17,4 +17,4 @@ void turnOnPin(int pin);
 void turnOnPinDuration(int pin, int duration);
 void setPWMPin(int pin, int pwmPct, int duration);
 void adjustPWMDown();
-void getPWMPinPercent(int pin, uint8_t *pwmPercent);
+uint8_t getPWMPinPercent(int pin);

--- a/STM32/AC/HeatCtrl/Src/HeatCtrl.c
+++ b/STM32/AC/HeatCtrl/Src/HeatCtrl.c
@@ -143,6 +143,9 @@ void adjustPWMDown()
 
 void getPWMPinPercent(int pin, uint8_t *pwmPercent)
 {
-    HeatCtrl *ctx = &heaters[pin];
-	*pwmPercent = ctx->pwmPercent;
+    if (pin >= 0 && pin < noOfHeaters)
+    {
+		HeatCtrl *ctx = &heaters[pin];
+		*pwmPercent = ctx->pwmPercent;
+    }
 }

--- a/STM32/AC/HeatCtrl/Src/HeatCtrl.c
+++ b/STM32/AC/HeatCtrl/Src/HeatCtrl.c
@@ -2,6 +2,7 @@
 #include "HeatCtrl.h"
 
 #define MAX_DURATION ((uint32_t) -1)
+#define MAX_TIMEOUT  60000 // Auto regulation time out from overheat prevention mode
 
 typedef struct HeatCtrl
 {
@@ -136,11 +137,11 @@ void adjustPWMDown()
     	if (ctx->pwmPercent >= 1)
     	{
     		ctx->pwmPercent -= 1;
-    		// If overheat prevention state has been enabled then extend the pwm duration
+    		// If the overheat prevention state has been enabled then extend the pwm duration
     		// such that the board tries to keep the maximal attainable temperature
     		// However, the board should ultimately go into safe mode by shutting off
     		// if no new commands are received in case of loss of communication.
-    		ctx->pwmDuration = (ctx->pwmDuration != MAX_DURATION) ? ctx->pwmDuration*20 : MAX_DURATION;
+    		ctx->pwmDuration = (ctx->pwmDuration != MAX_DURATION) ? MAX_TIMEOUT : MAX_DURATION;
     	}
     }
 }

--- a/STM32/AC/HeatCtrl/Src/HeatCtrl.c
+++ b/STM32/AC/HeatCtrl/Src/HeatCtrl.c
@@ -128,3 +128,21 @@ void setPWMPin(int pin, int pwmPct, int duration_ms)
         ctx->periodBegin = HAL_GetTick();
     }
 }
+
+void adjustPWMDown()
+{
+    for(HeatCtrl *ctx = heaters; ctx < &heaters[noOfHeaters]; ctx++)
+    {
+    	if (ctx->pwmPercent >= 1)
+    	{
+    		ctx->pwmPercent -= 1;
+    		ctx->pwmDuration = MAX_DURATION;
+    	}
+    }
+}
+
+void getPWMPinPercent(int pin, uint8_t *pwmPercent)
+{
+    HeatCtrl *ctx = &heaters[pin];
+	*pwmPercent = ctx->pwmPercent;
+}

--- a/STM32/AC/HeatCtrl/Src/HeatCtrl.c
+++ b/STM32/AC/HeatCtrl/Src/HeatCtrl.c
@@ -136,16 +136,24 @@ void adjustPWMDown()
     	if (ctx->pwmPercent >= 1)
     	{
     		ctx->pwmPercent -= 1;
-    		ctx->pwmDuration = MAX_DURATION;
+    		// If overheat prevention state has been enabled then extend the pwm duration
+    		// such that the board tries to keep the maximal attainable temperature
+    		// However, the board should ultimately go into safe mode by shutting off
+    		// if no new commands are received in case of loss of communication.
+    		ctx->pwmDuration = (ctx->pwmDuration != MAX_DURATION) ? ctx->pwmDuration*20 : MAX_DURATION;
     	}
     }
 }
 
-void getPWMPinPercent(int pin, uint8_t *pwmPercent)
+uint8_t getPWMPinPercent(int pin)
 {
     if (pin >= 0 && pin < noOfHeaters)
     {
 		HeatCtrl *ctx = &heaters[pin];
-		*pwmPercent = ctx->pwmPercent;
+		return ctx->pwmPercent;
     }
+    // In the case of passing -1 (i.e. targeting all ports) return 0
+    // As there are only options for setting target to 100 or 0 for all
+    // 0 is the always safe option.
+    return 0;
 }


### PR DESCRIPTION
An overheat prevention sequence is implemented. 

If the temperature reaches the MAX_TEMPERATURE then the board reduces its current PWM duty cycle until the board has reached the  MAX_TEMPERATURE again.

During the time when the board has exceeded the  MAX_TEMPERATURE the board disregards any input from a user that tries to increase the PWM duty cycle of the pins. If the user sends a command below the current PWM duty cycle i.e. to decrease temperature or shut off when the board has exceeded the  MAX_TEMPERATURE the command is accepted as normally. 