### PR TITLE
Change in input protocol + added test

### DIFF
--- a/STM32/Libraries/UnitTesting/src/stubs.cpp
+++ b/STM32/Libraries/UnitTesting/src/stubs.cpp
@@ -245,7 +245,7 @@ int main(int argc, char *argv[])
     if (line = testCMAverage()) { printf("TestSine failed at line %d\n", line); }
     if (line = testCalibration()) { printf("testCAProtocol failed at line %d\n", line); }
     if (line = testPortCtrl()) { printf("testPortCtrl failed at line %d\n", line); }
-    printf("All test performed\n");
+    printf("All tests run successfully\n");
 
     return 0;
 }

--- a/STM32/Libraries/UnitTesting/src/stubs.cpp
+++ b/STM32/Libraries/UnitTesting/src/stubs.cpp
@@ -232,9 +232,10 @@ int testPortCtrl()
     if (!caProtocol.testPortCtrl("p7 60\r\n", 7, PortCfg())) return __LINE__;
     if (!caProtocol.testPortCtrl("p7 60%\r\n", 7, PortCfg())) return __LINE__;
     if (!caProtocol.testPortCtrl("p7 52 60%\r\n", 7, PortCfg())) return __LINE__;
+    if (!caProtocol.testPortCtrl("p7 on 60e\r\n", 7, PortCfg())) return __LINE__;
     if (!caProtocol.testPortCtrl("p7 on 52 60\r\n", 7, PortCfg())) return __LINE__;
     if (!caProtocol.testPortCtrl("p7 sdfs 52 60%\r\n", 7, PortCfg())) return __LINE__;
-    if (caProtocol.portCtrl.undefCall != 5)  return __LINE__;
+    if (caProtocol.portCtrl.undefCall != 6)  return __LINE__;
     return 0;
 }
 

--- a/STM32/Libraries/Util/Src/CAProtocol.c
+++ b/STM32/Libraries/Util/Src/CAProtocol.c
@@ -248,7 +248,7 @@ void inputCAProtocol(CAProtocolCtx* ctx)
         {
             char *argv[4] = { 0 }; // There should not be more then 4 args.
             const char delim = ' ';
-            char *tok = strtok(input, &delim), *percent;
+            char *tok = strtok(input, &delim), percent = 0;
             int count=0, tmp;
             for (; count < 4 && tok; count++)
             {
@@ -264,8 +264,8 @@ void inputCAProtocol(CAProtocolCtx* ctx)
                 break;
             case 3: // pX on ZZZ% or YY
                 {
-                int argc = sscanf(argv[2], "%d%[%]", &count, &percent);
-                if (argc == 2)
+                int argc = sscanf(argv[2], "%d%c", &count, &percent);
+                if (argc == 2 && percent == '%')
                     ctx->portState(port, true, count, -1);
                 else if (argc == 1)
                     ctx->portState(port, true, 100, count);
@@ -274,7 +274,7 @@ void inputCAProtocol(CAProtocolCtx* ctx)
                 break;
                 }
             case 4: // pX on YY ZZZ%
-                if (sscanf(argv[2], "%d", &tmp) == 1 && sscanf(argv[3], "%d%[%]", &count, &percent) == 2)
+                if (sscanf(argv[2], "%d", &tmp) == 1 && sscanf(argv[3], "%d%c", &count, &percent) == 2 && percent == '%')
                     ctx->portState(port, true, count, tmp);
                 else
                     ctx->undefined(input);

--- a/STM32/Libraries/Util/Src/CAProtocol.c
+++ b/STM32/Libraries/Util/Src/CAProtocol.c
@@ -248,7 +248,7 @@ void inputCAProtocol(CAProtocolCtx* ctx)
         {
             char *argv[4] = { 0 }; // There should not be more then 4 args.
             const char delim = ' ';
-            char *tok = strtok(input, &delim), percent = 0;
+            char *tok = strtok(input, &delim), *percent;
             int count=0, tmp;
             for (; count < 4 && tok; count++)
             {


### PR DESCRIPTION
The inputCAProtocol method caused all PWM runs of pins to be rerouted to just an opening duration.

The format specifier scanning for '%' inputs has been changed. A test is added to ensure it does not read other chars. 