### PR TITLE
Library Update: All library functions updated to enable H7 control

### DIFF
--- a/STM32/Libraries/ADCMonitor/Inc/ADCMonitor.h
+++ b/STM32/Libraries/ADCMonitor/Inc/ADCMonitor.h
@@ -2,7 +2,11 @@
 #define _ADCMONITOR_H_
 
 #include <stdint.h>
+#if defined(STM32F401xx)
 #include "stm32f4xx_hal.h"
+#elif defined(STM32H753xx)
+#include "stm32h7xx_hal.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/STM32/Libraries/ADCMonitor/Inc/ADCMonitor.h
+++ b/STM32/Libraries/ADCMonitor/Inc/ADCMonitor.h
@@ -2,7 +2,7 @@
 #define _ADCMONITOR_H_
 
 #include <stdint.h>
-#if defined(STM32F401xx)
+#if defined(STM32F401xC)
 #include "stm32f4xx_hal.h"
 #elif defined(STM32H753xx)
 #include "stm32h7xx_hal.h"

--- a/STM32/Libraries/FLASH_readwrite/Inc/FLASH_H7_interface.h
+++ b/STM32/Libraries/FLASH_readwrite/Inc/FLASH_H7_interface.h
@@ -1,0 +1,25 @@
+/*
+ * FLASH_H7_interface.h
+ *
+ *  Created on: 22 Dec 2022
+ *      Author: matias
+ */
+
+#ifndef INC_FLASH_H7_INTERFACE_H_
+#define INC_FLASH_H7_INTERFACE_H_
+
+#include <stdint.h>
+#ifdef HAL_CRC_MODULE_ENABLED
+  #include "stm32h7xx_hal_crc.h"
+#endif
+
+uint32_t eraseSectors(uint32_t startAddress, uint16_t size);
+uint32_t writeToFlashH7(uint32_t startAddress, uint32_t *data, uint16_t size);
+void readFromFlashH7(uint32_t startAddress, uint32_t *data, uint16_t size);
+
+#ifdef HAL_CRC_MODULE_ENABLED
+	uint32_t writeToFlashCRC(CRC_HandleTypeDef *hcrc, uint32_t startAddress, uint32_t *data, uint16_t size);
+	void readFromFlashCRC(CRC_HandleTypeDef *hcrc, uint32_t startAddress, uint32_t *data, uint16_t size);
+#endif
+
+#endif /* INC_FLASH_H7_INTERFACE_H_ */

--- a/STM32/Libraries/FLASH_readwrite/Inc/FLASH_readwrite.h
+++ b/STM32/Libraries/FLASH_readwrite/Inc/FLASH_readwrite.h
@@ -8,9 +8,12 @@ Description:		Provides an interface to read and write FLASH memory.
 #define INC_FLASH_READWRITE_H_
 
 #include <stdint.h>
-#ifdef HAL_CRC_MODULE_ENABLED
+#if defined(HAL_CRC_MODULE_ENABLED) && defined(STM32F401xC)
   #include "stm32f4xx_hal_crc.h"
+#elif defined(HAL_CRC_MODULE_ENABLED) && defined(STM32H753xx)
+  #include "stm32h7xx_hal_crc.h"
 #endif
+
 
 void writeToFlash(uint32_t indx, uint32_t size, uint8_t *data);
 void readFromFlash(uint32_t indx, uint32_t size, uint8_t *data);
@@ -20,4 +23,3 @@ void readFromFlash(uint32_t indx, uint32_t size, uint8_t *data);
 	void readFromFlashSafe(CRC_HandleTypeDef *hcrc, uint32_t indx, uint32_t size, uint8_t *data);
 #endif
 #endif /* INC_FLASH_READWRITE_H_ */
-

--- a/STM32/Libraries/FLASH_readwrite/Inc/HAL_H7_otp.h
+++ b/STM32/Libraries/FLASH_readwrite/Inc/HAL_H7_otp.h
@@ -1,6 +1,13 @@
+/*
+ * HAL_H7_otp.h
+ *
+ *  Created on: 28 Dec 2022
+ *      Author: matias
+ */
+
 #pragma once
 
-#if defined(STM32F401xC) || defined(STM32F411xx)
+#if defined(STM32H753xx)
 #include <stdint.h>
 
 // Only defined formats will be supported. If code/version is bumped, it MUST be possible to read

--- a/STM32/Libraries/FLASH_readwrite/Src/FLASH_H7_interface.c
+++ b/STM32/Libraries/FLASH_readwrite/Src/FLASH_H7_interface.c
@@ -1,0 +1,193 @@
+/*
+ * FLASH_H7_interface.c
+ *
+ *  Created on: 22 Dec 2022
+ *      Author: matias
+ */
+
+/*
+ *  Library:			Read and write FLASH memory on STM32H7xx
+ *  Description:		Provides an interface to read and write FLASH memory.
+*/
+
+/* TODO: 1. Check the protection status of a FLASH sector before attempting to perform a write instruction. */
+
+// Only include content of file if project targets an STM32H7
+#if defined(STM32H753xx)
+
+#include "stm32h7xx_hal.h"
+#include <FLASH_H7_interface.h>
+#include <string.h>
+
+// Relevant sectors can be found in RM0433 Table 15
+#define START_ADDRESS_BANK1	0x08000000
+#define END_ADDRESS_BANK1	0x080FFFFF
+#define START_ADDRESS_BANK2 0x08100000
+#define END_ADDRESS_BANK2 	0x081FFFFF
+
+#define FLASH_WORD 				32 // 32 bytes
+#define DATA_ADDRESS_INCREMENT	8
+
+int flashSectorSize = 131072; // Each FLASH sector is 128kB (in binary)
+
+static uint32_t getSector(uint32_t address)
+{
+	uint32_t denominator = 0x00;
+	// Determine which memory bank address lies within
+	if (address > START_ADDRESS_BANK1 && address < END_ADDRESS_BANK1)
+		denominator = START_ADDRESS_BANK1;
+	else if (address > START_ADDRESS_BANK2 && address < END_ADDRESS_BANK2)
+		denominator = START_ADDRESS_BANK2;
+	else
+		return -1;
+
+	uint32_t sectorAddress = address-denominator;
+	int sector = sectorAddress/flashSectorSize;
+	return sector;
+}
+
+uint32_t eraseSectors(uint32_t startAddress, uint16_t size)
+{
+	static FLASH_EraseInitTypeDef EraseInitStruct;
+	uint32_t SECTORError;
+
+	// Unlock the FLASH to enable the flash control register access
+	HAL_FLASH_Unlock();
+
+	// Get the number of sector to erase from 1st sector
+	uint32_t startSector = getSector(startAddress);
+	uint32_t endSectorAddress = startAddress + size*4;
+	uint32_t endSector = getSector(endSectorAddress);
+
+	// Check that erase sector is valid
+	if (startSector == -1 || endSector == -1)
+		return -1;
+
+	// Fill EraseInit structure
+	EraseInitStruct.TypeErase     = FLASH_TYPEERASE_SECTORS;
+	EraseInitStruct.VoltageRange  = FLASH_VOLTAGE_RANGE_3;
+	EraseInitStruct.Sector        = startSector;
+
+	// Find the start memory bank to erase
+	if (startAddress < START_ADDRESS_BANK2 && endSectorAddress < START_ADDRESS_BANK2)
+		EraseInitStruct.Banks       = FLASH_BANK_1;
+	else if (startAddress > START_ADDRESS_BANK2)
+		EraseInitStruct.Banks    	= FLASH_BANK_2;
+	else EraseInitStruct.Banks    	= FLASH_BANK_BOTH;
+
+	EraseInitStruct.NbSectors     = (endSector - startSector) + 1;
+
+	// Erase the specified user FLASH area
+	if (HAL_FLASHEx_Erase(&EraseInitStruct, &SECTORError) != HAL_OK)
+	{
+		return HAL_FLASH_GetError();
+	}
+	HAL_FLASH_Lock();
+	return 0;
+}
+
+static uint32_t programSector(uint32_t startAddress, uint32_t *data, uint16_t size)
+{
+	HAL_FLASH_Unlock();
+	int dataIdx = 0;
+	for(uint32_t i=0; i<size; i++)
+	{
+		if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_FLASHWORD, startAddress, (uint32_t ) &data[dataIdx]) != HAL_OK)
+		{
+			// Error occurred while writing data in FLASH memory
+			return HAL_FLASH_GetError();
+		}
+		startAddress += FLASH_WORD;
+		dataIdx += DATA_ADDRESS_INCREMENT;
+	}
+	HAL_FLASH_Lock();
+	return 0;
+}
+
+// Write data to FLASH_ADDR+indx directly. This method does not
+// ensure any data integrity as data validation is performed.
+uint32_t writeToFlashH7(uint32_t startAddress, uint32_t *data, uint16_t size)
+{
+    __HAL_RCC_WWDG_CLK_DISABLE();
+
+    // Erase the sector before write
+    if (eraseSectors(startAddress, size) != 0)
+    	return -1;
+
+    // Write to sector
+    if (programSector(startAddress, data, size) != 0)
+    	return -1;
+    __HAL_RCC_WWDG_CLK_ENABLE();
+    return 0;
+}
+
+// Read from flash without checking data integrity if CRC module
+// is not enabled in project.
+void readFromFlashH7(uint32_t startAddress, uint32_t *data, uint16_t size)
+{
+    for(uint32_t i=0; i<size; i++)
+        *(data + i) = *((uint32_t *)(startAddress+i*4));
+}
+
+
+// If this check is not included the compiler will throw an
+// error for projects where CRC module is not enabled
+#ifdef HAL_CRC_MODULE_ENABLED
+uint32_t computeCRCH7(CRC_HandleTypeDef *hcrc, uint32_t *data, uint16_t size)
+{
+    // Convert data to uint32_t as needed for the CRC computation
+	uint32_t crcData[size];
+    memcpy(&crcData, data, size);
+
+    // Compute CRC of stored data
+    uint32_t crcVal = HAL_CRC_Calculate(hcrc, crcData, sizeof(crcData)/sizeof(uint32_t));
+    return crcVal;
+}
+
+// Write data to FLASH_ADDR+indx including CRC.
+uint32_t writeToFlashCRC(CRC_HandleTypeDef *hcrc, uint32_t startAddress, uint32_t *data, uint16_t size)
+{
+    __HAL_RCC_WWDG_CLK_DISABLE();
+
+    // Erase the sector before write
+    if (eraseSectors(startAddress, size) != 0)
+    	return -1;
+
+    // Save data supplied as input
+    if (programSector(startAddress, data, size) != 0)
+    	return -1;
+
+    // Compute CRC of data to be saved.
+    uint32_t crcVal = computeCRCH7(hcrc, data, size);
+    // Save CRC value
+    if (programSector(startAddress+size, &crcVal, 1) != 0)
+    	return -1;
+
+    __HAL_RCC_WWDG_CLK_ENABLE();
+    return 0;
+}
+
+
+// Read from flash without checking data integrity if CRC module
+// is not enabled in project.
+void readFromFlashCRC(CRC_HandleTypeDef *hcrc, uint32_t startAddress, uint32_t *data, uint16_t size)
+{
+    // Read data including CRC value
+    for(uint32_t i=0; i<size; i++)
+        *(data + i) = *( (uint32_t *)(startAddress+i) );
+
+    // Compute CRC of data read.
+    uint32_t crcVal = computeCRCH7(hcrc, data, size);
+
+    // Retrieve stored CRC value in flash.
+    uint32_t crcStored = 0;
+    memcpy(&crcStored, (uint32_t *)(startAddress+size), sizeof(uint32_t));
+
+    // If computed and stored CRC value does not match
+    // set data[0]=0xFF which resembles a clean FLASH i.e.
+    // default values are loaded and stored in boards.
+    if (crcStored != crcVal)
+    	*data = 0xFFFFFFFF;
+}
+#endif
+#endif

--- a/STM32/Libraries/FLASH_readwrite/Src/FLASH_readwrite.c
+++ b/STM32/Libraries/FLASH_readwrite/Src/FLASH_readwrite.c
@@ -5,6 +5,7 @@
  *  TODO: This is a very brute force implementation where no 'protocol' is used
  *        to read/write the flash. So flash layout should be defined.
 */
+#if defined(STM32F401xC)
 
 #include <stm32f4xx_hal.h>
 #include <FLASH_readwrite.h>
@@ -131,4 +132,5 @@ void readFromFlashSafe(CRC_HandleTypeDef *hcrc, uint32_t indx, uint32_t size, ui
     if (crcStored != crcVal)
     	*data = 0xFF;
 }
+#endif
 #endif

--- a/STM32/Libraries/FLASH_readwrite/Src/HAL_H7_otp.c
+++ b/STM32/Libraries/FLASH_readwrite/Src/HAL_H7_otp.c
@@ -1,0 +1,130 @@
+/*
+ * HAL_H7_otp.c
+ *
+ *  Created on: 28 Dec 2022
+ *      Author: matias
+ */
+
+// Only include content of file if project targets an STM32H7
+#if defined(STM32H753xx)
+
+#include <string.h>
+#include <stdbool.h>
+
+#include "HAL_H7_otp.h"
+#include "stm32h7xx_hal.h"
+#include "stm32h7xx.h"
+#include "FLASH_H7_interface.h"
+
+// Section 4 of Memory Bank 1 is write protected by default and is therefore dedicated
+// to OTP memory. This part of the memory is therefore not allowed to write to during
+// normal FLASH storing.
+#define FLASH_OTP_BASE		0x08080000
+#define OTP_FLASH_SECTOR	0x04
+
+uint32_t OTP_CLEAR_ADDRESS = 0xFFFFFFFF;
+
+#define FLASH_WORD_SIZE		32 // 32 bytes
+
+// This method can change the write-protection of a sector of BANK 1.
+// The documentation for this may be found in reference manual RM0433
+// section 4.5.1 and 4.9.16.
+static HAL_StatusTypeDef changeWriteProtectedSector(bool enable)
+{
+	if (!enable && ((FLASH->OPTCR & 0x01) == 0U))
+	{
+		// Remove write protection of 'OTP' sector
+		FLASH->WPSN_PRG1 |= (1UL << OTP_FLASH_SECTOR);
+
+		if (((FLASH->WPSN_PRG1 >> 4) & 0x01) != 0x01)
+			return HAL_ERROR;
+
+	}
+	else if (enable && ((FLASH->OPTCR & 0x01) == 0U))
+	{
+		// Enable write protection of 'OTP' sector
+		FLASH->WPSN_PRG1 &= ~(1UL << OTP_FLASH_SECTOR);
+
+		if (((FLASH->WPSN_PRG1 >> 4) & 0x01) != 0U)
+			return HAL_ERROR;
+	}
+	return HAL_OK;
+}
+
+// Check whether OTP data is already programmed on board.
+static int isOTPAvailable()
+{
+    volatile uint32_t* p = (uint32_t*) FLASH_OTP_BASE;
+    if (*p == OTP_CLEAR_ADDRESS)
+    	return 0;
+
+    // all OTP sectors is free
+    return 1;
+}
+
+// Read the current content of the OTP data.
+// @param boardInfo pointer to struct BoardInfo.
+// Return 0 on success else OTP_EMPTY and boardInfo will be unchanged.
+int HAL_otpRead(BoardInfo *boardInfo)
+{
+    if (!isOTPAvailable())
+        return OTP_EMPTY; // Nothing has been written to OTP area.
+
+    // Valid section found. Copy data to pointer since user should NOT get direct access to OTP area.
+    void* otpArea = (void*) FLASH_OTP_BASE;
+    memcpy(boardInfo->data, otpArea, sizeof(boardInfo->data)/sizeof(uint32_t));
+
+    return OTP_SUCCESS;
+}
+
+// Write BoardInfo to OTP flash memory.
+// @param boardInfo pointer to struct BoardInfo.
+// Return 0 on success else OTP_WRITE_FAIL if all OTP sections is written.
+const int HAL_otpWrite(const BoardInfo *boardInfo)
+{
+    // Check the version of the Board info
+    if (boardInfo->otpVersion > OTP_VERSION || boardInfo->otpVersion == 0) {
+        return OTP_WRITE_FAIL;
+    }
+
+    // If sector has already been written to erase first.
+    if (isOTPAvailable())
+    {
+    	if (eraseSectors(FLASH_OTP_BASE, sizeof(boardInfo->data)/sizeof(uint32_t)) != 0)
+    		return OTP_WRITE_FAIL;
+    }
+
+    if (HAL_FLASH_Unlock() != HAL_OK)
+        return OTP_WRITE_FAIL;
+
+    // Unlock Flash OPT registry that allows removal of write protection of FLASH section
+    if (HAL_FLASH_OB_Unlock() != HAL_OK)
+    	return OTP_WRITE_FAIL;
+
+    // Remove write protection of 'OTP' sector
+    if (changeWriteProtectedSector(false) != HAL_OK)
+    	return OTP_WRITE_FAIL;
+
+    // Write board info to sector using word size.
+    uint32_t otpStartAddress = FLASH_OTP_BASE;
+    for (int i=0; i<sizeof(boardInfo->data)/sizeof(uint32_t); i++)
+    {
+        if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_FLASHWORD, otpStartAddress, (uint32_t) &boardInfo->data[i]) != HAL_OK)
+        {
+        	HAL_FLASH_OB_Lock();
+            HAL_FLASH_Lock();
+            return OTP_WRITE_FAIL;
+        }
+        otpStartAddress += FLASH_WORD_SIZE;
+    }
+
+    if (changeWriteProtectedSector(true) != HAL_OK)
+    	return OTP_WRITE_FAIL;
+
+    if (HAL_FLASH_OB_Lock() != HAL_OK)
+    	return OTP_WRITE_FAIL;
+
+    HAL_FLASH_Lock();
+    return OTP_SUCCESS;
+}
+#endif

--- a/STM32/Libraries/FLASH_readwrite/Src/HAL_otp.c
+++ b/STM32/Libraries/FLASH_readwrite/Src/HAL_otp.c
@@ -8,6 +8,9 @@
  * Writing: Find the next free block and write version info to this block section
  */
 
+// Only include content of file if project targets an STM32F4xx
+#if defined(STM32F401xC) || defined(STM32F411xx)
+
 #include <string.h>
 
 #include "HAL_otp.h"
@@ -105,3 +108,4 @@ const int HAL_otpWrite(const BoardInfo *boardInfo)
     HAL_FLASH_Lock();
     return OTP_SUCCESS;
 }
+#endif

--- a/STM32/Libraries/I2C/Inc/MCP4725.h
+++ b/STM32/Libraries/I2C/Inc/MCP4725.h
@@ -8,7 +8,11 @@
 #ifndef INC_MCP4725_H_
 #define INC_MCP4725_H_
 
+#if defined(STM32F401xC)
 #include "stm32f4xx_hal.h"
+#elif defined(STM32H753xx)
+#include "stm32h7xx_hal.h"
+#endif
 #include "MCP4725.h"
 #include <stdbool.h>
 

--- a/STM32/Libraries/I2C/Inc/honeywellZephyrI2C.h
+++ b/STM32/Libraries/I2C/Inc/honeywellZephyrI2C.h
@@ -4,7 +4,11 @@
  * Description:
  * Provides an interface to communicate with the honeywell zephyr air flow sensor.
  */
+#if defined(STM32F401xC)
 #include "stm32f4xx_hal.h"
+#elif defined(STM32H753xx)
+#include "stm32h7xx_hal.h"
+#endif
 
 // Get sensor serial number
 HAL_StatusTypeDef honeywellZephyrSerial(I2C_HandleTypeDef* hi2c, uint32_t *serialNB);

--- a/STM32/Libraries/I2C/Inc/sht35.h
+++ b/STM32/Libraries/I2C/Inc/sht35.h
@@ -11,8 +11,11 @@
 
 
 #endif /* INC_SHT35_H_ */
+#if defined(STM32F401xC)
 #include "stm32f4xx_hal.h"
-
+#elif defined(STM32H753xx)
+#include "stm32h7xx_hal.h"
+#endif
 #include <stdbool.h>
 #include "assert.h"
 #include "string.h"

--- a/STM32/Libraries/I2C/Inc/si7051.h
+++ b/STM32/Libraries/I2C/Inc/si7051.h
@@ -8,7 +8,11 @@
 #ifndef INC_SI7051_H_
 #define INC_SI7051_H_
 
+#if defined(STM32F401xC)
 #include "stm32f4xx_hal.h"
+#elif defined(STM32H753xx)
+#include "stm32h7xx_hal.h"
+#endif
 HAL_StatusTypeDef si7051Temp(I2C_HandleTypeDef *hi2c1, float* siValue);
 
 #endif /* INC_SI7051_H_ */

--- a/STM32/Libraries/I2C/Src/honeywellZephyrI2C.c
+++ b/STM32/Libraries/I2C/Src/honeywellZephyrI2C.c
@@ -1,7 +1,6 @@
 /* Description:
  * Provides an interface to communicate with the honeywell zephyr air flow sensor. */
 
-#include "stm32f4xx_hal.h"
 #include "honeywellZephyrI2C.h"
 
 #define ZephyrADDR 0x49

--- a/STM32/Libraries/SPI/Inc/ADS1120.h
+++ b/STM32/Libraries/SPI/Inc/ADS1120.h
@@ -1,6 +1,10 @@
 #pragma once
 
-#include <stm32f4xx_hal.h>
+#if defined(STM32F401xC)
+#include "stm32f4xx_hal.h"
+#elif defined(STM32H753xx)
+#include "stm32h7xx_hal.h"
+#endif
 #include <StmGpio.h>
 
 // Specific structure for the current setup of the ADS1120.

--- a/STM32/Libraries/SPI/Inc/max31855.h
+++ b/STM32/Libraries/SPI/Inc/max31855.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#if defined(STM32F401xC)
 #include "stm32f4xx_hal.h"
+#elif defined(STM32H753xx)
+#include "stm32h7xx_hal.h"
+#endif
 #include "StmGpio.h"
 
 // error codes

--- a/STM32/Libraries/USBprint/Inc/USBprint.h
+++ b/STM32/Libraries/USBprint/Inc/USBprint.h
@@ -9,7 +9,11 @@
 #define INC_USBPRINT_H_
 
 #include <unistd.h>
+#if defined(STM32F401xx)
 #include "stm32f4xx_hal.h"
+#elif defined(STM32H753xx)
+#include "stm32h7xx_hal.h"
+#endif
 #include "stdarg.h"
 
 // Wrap vsnprintf(char *str, size_t size, const char *format, va_list ap)

--- a/STM32/Libraries/USBprint/Inc/USBprint.h
+++ b/STM32/Libraries/USBprint/Inc/USBprint.h
@@ -9,7 +9,7 @@
 #define INC_USBPRINT_H_
 
 #include <unistd.h>
-#if defined(STM32F401xx)
+#if defined(STM32F401xC)
 #include "stm32f4xx_hal.h"
 #elif defined(STM32H753xx)
 #include "stm32h7xx_hal.h"

--- a/STM32/Libraries/Util/Inc/CAProtocol.h
+++ b/STM32/Libraries/Util/Inc/CAProtocol.h
@@ -9,7 +9,11 @@
 #define INC_CAPROTOCOL_H_
 
 #include <stdbool.h>
+#if defined(STM32F401xC)
 #include "HAL_otp.h"
+#elif defined(STM32H753xx)
+#include "HAL_H7_otp.h"
+#endif
 
 typedef struct
 {

--- a/STM32/Libraries/Util/Inc/StmGpio.h
+++ b/STM32/Libraries/Util/Inc/StmGpio.h
@@ -10,7 +10,12 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#if defined(STM32F401xC)
 #include "stm32f4xx_hal.h"
+#elif defined(STM32H753xx)
+#include "stm32h7xx_hal.h"
+#endif
+
 
 #define stmSetGpio(x, activate) { (x).set(&(x), activate); }
 #define stmGetGpio(x)           (x).get(&(x))

--- a/STM32/Libraries/Util/Src/CAProtocolStm.c
+++ b/STM32/Libraries/Util/Src/CAProtocolStm.c
@@ -1,13 +1,24 @@
 #include <string.h>
-#include "stm32f4xx_hal.h"
 #include "CAProtocolStm.h"
 #include "usb_device.h"
 #include "USBprint.h"
 #include "usb_cdc_fops.h"
 #include "jumpToBootloader.h"
-#include "HAL_otp.h"
 #include "systemInfo.h"
 #include "time32.h"
+
+#if defined(STM32F401xC)
+#include "stm32f4xx_hal.h"
+#include "HAL_otp.h"
+#elif defined(STM32H753xx)
+#include "stm32h7xx_hal.h"
+#include "HAL_H7_otp.h"
+#endif
+
+#if defined(STM32H753xx)
+#define RCC_FLAG_WWDGRST RCC_FLAG_WWDG1RST
+#define RCC_FLAG_IWDGRST RCC_FLAG_IWDG1RST
+#endif
 
 void HALundefined(const char *input)
 {

--- a/STM32/Libraries/Util/Src/systeminfo.c
+++ b/STM32/Libraries/Util/Src/systeminfo.c
@@ -86,7 +86,7 @@ const char* systemInfo()
     len += snprintf(&buf[len], sizeof(buf) - len, "MCU Family: %s\r\n", mcuType());
     len += snprintf(&buf[len], sizeof(buf) - len, "Software Version: %s\r\n", GIT_VERSION);
     len += snprintf(&buf[len], sizeof(buf) - len, "Compile Date: %s\r\n", GIT_DATE);
-    len += snprintf(&buf[len], sizeof(buf) - len, "Git SHA %s\r\n", GIT_SHA);
+    len += snprintf(&buf[len], sizeof(buf) - len, "Git SHA: %s\r\n", GIT_SHA);
     switch(info.otpVersion)
     {
     case OTP_VERSION_1:

--- a/STM32/Libraries/Util/Src/systeminfo.c
+++ b/STM32/Libraries/Util/Src/systeminfo.c
@@ -4,10 +4,15 @@
 
 #include <stdio.h>
 
+#if defined(STM32F401xC)
 #include "stm32f4xx_hal.h"
+#include "HAL_otp.h"
+#elif defined(STM32H753xx)
+#include "stm32h7xx_hal.h"
+#include "HAL_H7_otp.h"
+#endif
 #include "systemInfo.h"
 #include "githash.h"
-#include "HAL_otp.h"
 
 // F4xx UID
 #define ID1 *((unsigned long *) (UID_BASE))

--- a/STM32/Libraries/jumpToBootloader/Inc/jumpToBootloader.h
+++ b/STM32/Libraries/jumpToBootloader/Inc/jumpToBootloader.h
@@ -8,10 +8,6 @@
 #ifndef INC_JUMPTOBOOTLOADER_H_
 #define INC_JUMPTOBOOTLOADER_H_
 
-
-
-#endif /* INC_JUMPTOBOOTLOADER_H_ */
-
 #if defined(STM32F401xC)
 #include "stm32f4xx_hal.h"
 #elif defined(STM32H753xx)
@@ -20,5 +16,8 @@
 
 
 void JumpToBootloader(void);
-
 void checkBootloader(char * inputBuffer);
+
+#endif /* INC_JUMPTOBOOTLOADER_H_ */
+
+

--- a/STM32/Libraries/jumpToBootloader/Inc/jumpToBootloader.h
+++ b/STM32/Libraries/jumpToBootloader/Inc/jumpToBootloader.h
@@ -12,7 +12,12 @@
 
 #endif /* INC_JUMPTOBOOTLOADER_H_ */
 
+#if defined(STM32F401xC)
 #include "stm32f4xx_hal.h"
+#elif defined(STM32H753xx)
+#include "stm32h7xx_hal.h"
+#endif
+
 
 void JumpToBootloader(void);
 


### PR DESCRIPTION
Update to the library functions to extend functionality to work on STM32H7. 

The majority of the library functions simply need to include the correct 'hal' file corresponding with the MCU at hand.

New library functions for FLASH and OTP programming has been added. The FLASH interface differs in between the H7 and F4 MCUs meaning separate files have been added for these. 

There is no dedicated OTP memory for the STM32H7 MCU. Sector 4 of memory Bank 1 has been allocated for this information as it is write-protected by default. Hence, the sector can not be overridden by a normal flash write, however it is not possible to secure against mass erase of this area. 