### PR TITLE
Library: Update ADCMean to enforce fractional number output

### DIFF
--- a/STM32/Libraries/ADCMonitor/Src/ADCmonitor.c
+++ b/STM32/Libraries/ADCMonitor/Src/ADCmonitor.c
@@ -97,7 +97,7 @@ double ADCMean(const int16_t *pData, uint16_t channel)
         sum += pData[sampleId*ADCMonitorData.noOfChannels + channel];
     }
 
-    return (sum / ADCMonitorData.noOfSamples);
+    return (((double) sum) / ((double) ADCMonitorData.noOfSamples));
 }
 
 inline float ADCMeanBitShift(const int16_t *pData, uint16_t channel, uint8_t shiftIdx)


### PR DESCRIPTION
Cast both the sum and divider to doubles before carrying out calculation. Previously the division was done on unsigned integers meaning the output always lost its fractional part.