### PR TITLE
Test: Code generation test

### DIFF
--- a/.github/workflows/stm32build.yml
+++ b/.github/workflows/stm32build.yml
@@ -71,18 +71,18 @@ jobs:
         fi
   run_static_tests:
     needs: changes
-      if: ${{ needs.changes.outputs.packages != '[]' && needs.changes.outputs.packages != '' }}
-      strategy:
-        matrix:
-          # Parse JSON array containing names of all filters matching any of changed files
-          package: ${{ fromJSON(needs.changes.outputs.packages) }}
-      runs-on: ubuntu-latest
-      steps:
-      - uses: actions/checkout@v3   # gets file environment with submodule included for libraries
-        with:
-          submodules: 'true'
-      - name: Run static tests
-        run: STM32/CommonTests/code_generation_test.sh STM32/${{ matrix.package }}
+    if: ${{ needs.changes.outputs.packages != '[]' && needs.changes.outputs.packages != '' }}
+    strategy:
+      matrix:
+        # Parse JSON array containing names of all filters matching any of changed files
+        package: ${{ fromJSON(needs.changes.outputs.packages) }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3   # gets file environment with submodule included for libraries
+      with:
+        submodules: 'true'
+    - name: Run static tests
+      run: STM32/CommonTests/code_generation_test.sh STM32/${{ matrix.package }}
   build:
     needs: changes
     permissions:

--- a/.github/workflows/stm32build.yml
+++ b/.github/workflows/stm32build.yml
@@ -35,7 +35,7 @@ jobs:
           LightController: STM32/LightController/**
           OTP: STM32/OTP/**
           Temperature: STM32/Temperature/**
-  run_tests:
+  run_unittests:
     needs: changes
     if: ${{ needs.changes.outputs.packages != '[]' && needs.changes.outputs.packages != '' }}
     strategy:
@@ -69,6 +69,20 @@ jobs:
           echo "Test failed"
           exit 1
         fi
+  run_static_tests:
+    needs: changes
+      if: ${{ needs.changes.outputs.packages != '[]' && needs.changes.outputs.packages != '' }}
+      strategy:
+        matrix:
+          # Parse JSON array containing names of all filters matching any of changed files
+          package: ${{ fromJSON(needs.changes.outputs.packages) }}
+      runs-on: ubuntu-latest
+      steps:
+      - uses: actions/checkout@v3   # gets file environment with submodule included for libraries
+        with:
+          submodules: 'true'
+      - name: Run static tests
+        run: STM32/CommonTests/code_generation_test.sh STM32/${{ matrix.package }}
   build:
     needs: changes
     permissions:

--- a/.github/workflows/stm32build.yml
+++ b/.github/workflows/stm32build.yml
@@ -69,18 +69,7 @@ jobs:
           echo "Test failed"
           exit 1
         fi
-  run_static_tests:
-    needs: changes
-    if: ${{ needs.changes.outputs.packages != '[]' && needs.changes.outputs.packages != '' }}
-    strategy:
-      matrix:
-        # Parse JSON array containing names of all filters matching any of changed files
-        package: ${{ fromJSON(needs.changes.outputs.packages) }}
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3   # gets file environment with submodule included for libraries
-      with:
-        submodules: 'true'
+    # Run the static code analysis test.
     - name: Run static tests
       run: STM32/CommonTests/code_generation_test.sh STM32/${{ matrix.package }}
   build:

--- a/STM32/AC/Core/Src/main.c
+++ b/STM32/AC/Core/Src/main.c
@@ -91,9 +91,9 @@ int main(void)
 
   /* Initialize all configured peripherals */
   MX_GPIO_Init();
+  MX_ADC1_Init();
   MX_DMA_Init();
   MX_USB_DEVICE_Init();
-  MX_ADC1_Init();
   MX_TIM2_Init();
   MX_WWDG_Init();
   MX_IWDG_Init();

--- a/STM32/AC/Core/Src/main.c
+++ b/STM32/AC/Core/Src/main.c
@@ -91,9 +91,9 @@ int main(void)
 
   /* Initialize all configured peripherals */
   MX_GPIO_Init();
-  MX_ADC1_Init();
   MX_DMA_Init();
   MX_USB_DEVICE_Init();
+  MX_ADC1_Init();
   MX_TIM2_Init();
   MX_WWDG_Init();
   MX_IWDG_Init();

--- a/STM32/CommonTests/code_generation_test.sh
+++ b/STM32/CommonTests/code_generation_test.sh
@@ -1,0 +1,64 @@
+#! /bin/bash
+
+# This script checks that a project has initialised the ADC and DMA correctly
+# both in the .ioc and main file by checking the auto-generated code from STM. 
+# If the .ioc-file or the main file initialises them in reverse order the
+# ADC will not start, in which case the script fails. 
+
+# INPUTS:
+# path:         The script takes one input parameter which should be the path 
+#               to the top layer of the project of interest.
+#
+# OUTPUT:
+# exit value:   If the test is successfull the exit value is 0 otherwise 1.
+
+# Get the project path 
+path=$1
+if [[ ! -d "$path" ]]; then
+    echo "Error: Missing project path."
+    exit 1
+fi
+
+# Step 1: Ensure correct initialisation in .ioc-file.
+# Check for project .ioc file
+project_ioc=$(find $path/ -iname *.ioc)
+
+# Find function sort list
+function_list=$(cat $project_ioc | grep ProjectManager.functionlistsort)
+function_list_line_number=$(cat $project_ioc | grep -n ProjectManager.functionlistsort | cut -d : -f 1)
+
+# Find indices for MX_ADC and MX_DMA
+adc_idx=$(echo "$function_list" | grep -oE '([0-9]+)-MX_ADC' | awk -F'-' '{print $1}')
+dma_idx=$(echo "$function_list" | grep -oE '([0-9]+)-MX_DMA' | awk -F'-' '{print $1}')
+
+# If DMA or ADC is not used exit script.
+if [[ -z "$adc_idx" || -z "$dma_idx" ]]; then
+    exit 0
+fi
+
+# Ensure dma_idx is lower than adc_idx
+for idx in $adc_idx; do
+    if [[ $idx -lt $dma_idx ]]; then
+        echo "MX_DMA needs to before initialised before MX_ADC in line $function_list_line_number in $project_ioc."
+        exit 1
+    fi
+done
+
+## Step 2: Ensure correct initialisation in main file.
+project_main=$(find $path/Core/Src/ -iname main.c)
+
+# Find initialisation of MX_ADCx_Init() and MX_DMA_Init() in main.c
+adc_main_idx=$(cat $project_main | grep -n 'MX_ADC[0-9]_Init()'| cut -d : -f 1)
+dma_main_idx=$(cat $project_main | grep -n 'MX_DMA_Init()' | cut -d : -f 1)
+
+# Ensure dma_main_idx is lower than adc_main_idx
+# NOTE: No need to check if ADC or DMA is used in project as
+#       it has already been checked in previous step.
+for idx in $adc_main_idx; do
+    if [[ $idx -lt $dma_main_idx ]]; then
+        echo "MX_DMA_Init() needs to before initialised before MX_ADCx_Init() in $project_main."
+        echo "MX_DMA_Init() is initialised in line $dma_main_idx and MX_ADCx_Init() is initialised in line $adc_main_idx."
+        exit 1
+    fi
+done
+exit 0

--- a/STM32/CommonTests/code_generation_test.sh
+++ b/STM32/CommonTests/code_generation_test.sh
@@ -47,13 +47,13 @@ done
 ## Step 2: Ensure correct initialisation in main file.
 project_main=$(find $path/Core/Src/ -iname main.c)
 
-# Find initialisation of MX_ADCx_Init() and MX_DMA_Init() in main.c
+# Find lines where MX_ADCx_Init() and MX_DMA_Init() are initialised in main.c
 adc_main_idx=$(cat $project_main | grep -n 'MX_ADC[0-9]_Init()'| cut -d : -f 1)
 dma_main_idx=$(cat $project_main | grep -n 'MX_DMA_Init()' | cut -d : -f 1)
 
 # Ensure dma_main_idx is lower than adc_main_idx
 # NOTE: No need to check if ADC or DMA is used in project as
-#       it has already been checked in previous step.
+#       this has already been checked in previous step.
 for idx in $adc_main_idx; do
     if [[ $idx -lt $dma_main_idx ]]; then
         echo "MX_DMA_Init() needs to before initialised before MX_ADCx_Init() in $project_main."


### PR DESCRIPTION
A new static code test is added for the STM32 projects. 

It checks that the DMA is initialised before the ADC component. If the ADC is initialised first it will never start. This wrong initialisation is caused by a bug in the STMCubeMX  auto-generation of code.

It is called whenever a change to an STM32 project is made. 