### PR TITLE
Feature/dfu script

### DIFF
--- a/STM32/AC/HeatCtrl/Inc/HeatCtrl.h
+++ b/STM32/AC/HeatCtrl/Inc/HeatCtrl.h
@@ -27,4 +27,3 @@ void turnOnPinDuration(int pin, int duration);
 void setPWMPin(int pin, int pwmPct, int duration);
 void adjustPWMDown();
 uint8_t getPWMPinPercent(int pin);
-void updateHeaterPhaseControl();

--- a/STM32/AC/HeatCtrl/Inc/HeatCtrl.h
+++ b/STM32/AC/HeatCtrl/Inc/HeatCtrl.h
@@ -3,7 +3,16 @@
 #include <stdint.h>
 #include "StmGpio.h"
 
+/***************************************************************************************************
+** DEFINES
+***************************************************************************************************/
+
 #define MAX_NO_HEATERS 4
+#define PWM_PERIOD_MS  1000
+
+/***************************************************************************************************
+** PUBLIC FUNCTIONS
+***************************************************************************************************/
 
 // Loop handling
 struct HeatCtrl* heatCtrlAdd(StmGpio *out, StmGpio * button);
@@ -18,3 +27,4 @@ void turnOnPinDuration(int pin, int duration);
 void setPWMPin(int pin, int pwmPct, int duration);
 void adjustPWMDown();
 uint8_t getPWMPinPercent(int pin);
+void updateHeaterPhaseControl();

--- a/STM32/AC/HeatCtrl/Src/HeatCtrl.c
+++ b/STM32/AC/HeatCtrl/Src/HeatCtrl.c
@@ -177,7 +177,7 @@ void updateHeaterPhaseControl()
 
     /* Starting at the end and working backwards means all the periodBegins are set BACK in time, 
     ** instead of forwards. This means the tdiff_u32() function will produce normal results */
-    for(HeatCtrl *ctx = &heaters[noOfHeaters]; ctx >= heaters; ctx--)
+    for(HeatCtrl *ctx = &heaters[noOfHeaters-1]; ctx >= heaters; ctx--)
     {
         period_begin -= (ctx->pwmPercent * ctx->pwmPeriod) / 100;
         ctx->periodBegin = period_begin;

--- a/STM32/AC/HeatCtrl/Src/HeatCtrl.c
+++ b/STM32/AC/HeatCtrl/Src/HeatCtrl.c
@@ -78,19 +78,19 @@ void heaterLoop()
             setPwmPercent(pCtrl, 0);
         }
 
-        // Use modules '%' to get the on/off section in PWM period.
-        // If percent is 0, heat shall be off (period is invalid)
-        tdiff = tdiff_u32(now, pCtrl->pwmBegin);
+        /* If percent is 0, heat shall be off (period is invalid) */
         if (pCtrl->pwmPercent == 0)
         {
             pCtrl->heater->set(pCtrl->heater, false);
         }
+        /* Otherwise, use modules '%' to get the on/off section in PWM period. */
         else
         {
+            tdiff = tdiff_u32(now, pCtrl->pwmBegin);
             uint32_t periodOn = (pCtrl->pwmPercent * pCtrl->pwmPeriod) / 100;
             tdiff = tdiff % pCtrl->pwmPeriod;
 
-            pCtrl->heater->set(pCtrl->heater, tdiff <= periodOn);
+            pCtrl->heater->set(pCtrl->heater, tdiff < periodOn);
         }
     }
 }
@@ -211,7 +211,7 @@ void updateHeaterPhaseControl()
         /* If the totalPeriod reaches the end of the period, wrap it around to the beginning so 
         ** that none of the heaters are more than one second delayed in starting */
         totalPeriod += (ctx->pwmPercent * ctx->pwmPeriod) / 100;
-        if(totalPeriod > PWM_PERIOD_MS)
+        if(totalPeriod >= PWM_PERIOD_MS)
         {
             totalPeriod -= PWM_PERIOD_MS;
         }

--- a/STM32/AC/HeatCtrl/Src/HeatCtrl.c
+++ b/STM32/AC/HeatCtrl/Src/HeatCtrl.c
@@ -200,7 +200,9 @@ uint8_t getPWMPinPercent(int pin)
 */
 void updateHeaterPhaseControl() 
 {
-    /* Start from one period ago, so everything is time aligned */
+    /* Must start in the past, because otherwise the tdiff_u32 function (in heaterLoop() will give 
+    ** odd results until all the heater periodBegins are in the past relative to "now". Start from 
+    ** exactly one period ago, so everything is time aligned */
     const uint32_t pwmBegin = HAL_GetTick() - PWM_PERIOD_MS;
     uint32_t totalPeriod = 0;
     

--- a/STM32/AC/HeatCtrl/Src/HeatCtrl.c
+++ b/STM32/AC/HeatCtrl/Src/HeatCtrl.c
@@ -30,7 +30,7 @@ HeatCtrl* heatCtrlAdd(StmGpio *heater, StmGpio * button)
     noOfHeaters++;
 
     ctx->pwmDuration = 0;     // Default is off.
-    ctx->pwmPeriod   = 1000;  // default value, 1 seconds.
+    ctx->pwmPeriod   = PWM_PERIOD_MS;  // default value, 1 seconds.
     ctx->pwmPercent  = 0;     // Default is off.
 
     ctx->heater = heater;
@@ -77,6 +77,7 @@ void allOff()
         ctx->pwmPercent = 0;
         ctx->pwmDuration = 0;
     }
+    updateHeaterPhaseControl();
 }
 
 void allOn()
@@ -86,6 +87,7 @@ void allOn()
         ctx->pwmPercent = 100;
         ctx->pwmDuration = MAX_DURATION;
     }
+    updateHeaterPhaseControl();
 }
 
 void turnOffPin(int pin)
@@ -95,6 +97,7 @@ void turnOffPin(int pin)
         HeatCtrl *ctx = &heaters[pin];
         ctx->pwmPercent = 0;
         ctx->pwmDuration = 0;
+        updateHeaterPhaseControl();
     }
 }
 
@@ -105,6 +108,7 @@ void turnOnPin(int pin)
         HeatCtrl *ctx = &heaters[pin];
         ctx->pwmPercent = 100;
         ctx->pwmDuration = MAX_DURATION;
+        updateHeaterPhaseControl();
     }
 }
 
@@ -115,7 +119,7 @@ void turnOnPinDuration(int pin, int duration_ms)
         HeatCtrl *ctx = &heaters[pin];
         ctx->pwmPercent = 100;
         ctx->pwmDuration = (duration_ms >= 0) ? duration_ms : MAX_DURATION; // Negative value means forever.
-        ctx->periodBegin = HAL_GetTick();
+        updateHeaterPhaseControl();
     }
 }
 
@@ -126,7 +130,7 @@ void setPWMPin(int pin, int pwmPct, int duration_ms)
         HeatCtrl *ctx = &heaters[pin];
         ctx->pwmPercent = pwmPct;
         ctx->pwmDuration = (duration_ms >= 0) ? duration_ms : MAX_DURATION; // Negative value means forever.
-        ctx->periodBegin = HAL_GetTick();
+        updateHeaterPhaseControl();
     }
 }
 
@@ -134,15 +138,17 @@ void adjustPWMDown()
 {
     for(HeatCtrl *ctx = heaters; ctx < &heaters[noOfHeaters]; ctx++)
     {
-    	if (ctx->pwmPercent >= 1)
-    	{
-    		ctx->pwmPercent -= 1;
-    		// If the overheat prevention state has been enabled then extend the pwm duration
-    		// such that the board tries to keep the maximal attainable temperature
-    		// However, the board should ultimately go into safe mode by shutting off
-    		// if no new commands are received in case of loss of communication.
-    		ctx->pwmDuration = (ctx->pwmDuration != MAX_DURATION) ? MAX_TIMEOUT : MAX_DURATION;
-    	}
+        if (ctx->pwmPercent >= 1)
+        {
+            ctx->pwmPercent -= 1;
+            // If the overheat prevention state has been enabled then extend the pwm duration
+            // such that the board tries to keep the maximal attainable temperature
+            // However, the board should ultimately go into safe mode by shutting off
+            // if no new commands are received in case of loss of communication.
+            ctx->pwmDuration = (ctx->pwmDuration != MAX_DURATION) ? MAX_TIMEOUT : MAX_DURATION;
+
+            updateHeaterPhaseControl();
+        }
     }
 }
 
@@ -150,11 +156,30 @@ uint8_t getPWMPinPercent(int pin)
 {
     if (pin >= 0 && pin < noOfHeaters)
     {
-		HeatCtrl *ctx = &heaters[pin];
-		return ctx->pwmPercent;
+        HeatCtrl *ctx = &heaters[pin];
+        return ctx->pwmPercent;
     }
     // In the case of passing -1 (i.e. targeting all ports) return 0
     // As there are only options for setting target to 100 or 0 for all
     // 0 is the always safe option.
     return 0;
+}
+
+/*!
+** @brief Aligns phase control of all PWM'd heaters
+**
+** Aligns the start and end of the "on" pulse of all channels (excluding "always on" or "always off"
+** channels) by modifying the "periodBegin" variable for each heater
+*/
+void updateHeaterPhaseControl() 
+{
+    uint32_t period_begin = HAL_GetTick();
+
+    /* Starting at the end and working backwards means all the periodBegins are set BACK in time, 
+    ** instead of forwards. This means the tdiff_u32() function will produce normal results */
+    for(HeatCtrl *ctx = &heaters[noOfHeaters]; ctx >= heaters; ctx--)
+    {
+        period_begin -= (ctx->pwmPercent * ctx->pwmPeriod) / 100;
+        ctx->periodBegin = period_begin;
+    }
 }

--- a/unit_testing/AC/AC_tests.cpp
+++ b/unit_testing/AC/AC_tests.cpp
@@ -139,3 +139,115 @@ TEST_F(ACHeaterCtrl, setPWMPin)
         setPWMPin(i, 0, 0);
     }
 }
+
+TEST_F(ACHeaterCtrl, adjustPWMDown) 
+{
+    static const int STAGGER = 5;
+    int start_pwm[MAX_NO_HEATERS] = {0};
+
+    /* Setup staggered PWMs on different pins */
+    for(int i = 0; i < MAX_NO_HEATERS; i++) 
+    {
+        start_pwm[i] = STAGGER * (i + 1);
+        setPWMPin(i, start_pwm[i], 0);
+    }
+
+    /* + 1 added to ensure going below 0 is tested for every channel, including the last one */
+    for(int i = 0; i < STAGGER * MAX_NO_HEATERS + 1; i++)
+    {
+        for(int j = 0; j < MAX_NO_HEATERS; j++)
+        {
+            if(start_pwm[j] > i)
+            {
+                EXPECT_EQ(getPWMPinPercent(j), STAGGER * (j + 1) - i) << "Heater " << j;
+            }
+            else
+            {
+                EXPECT_EQ(getPWMPinPercent(j), 0) << "Heater " << j;
+            }
+            
+        }
+
+        adjustPWMDown();
+    }
+}
+
+/* getPWMPinPercent not tested due to instrumentation issues. It is sort of tested implicitly by 
+** other tests */
+
+TEST_F(ACHeaterCtrl, updateHeaterPhaseControl)
+{
+    static const int PWM_PERIOD = heaters[MAX_NO_HEATERS-1].pwmPeriod;
+    static const int TICK_TIME  = MAX_NO_HEATERS * PWM_PERIOD;
+
+    forceTick(TICK_TIME);
+    turnOnTest();
+
+    /* Note: some dubious practice here. HeatCtrl is supposed to be private, but by including the .c
+    ** file (instead of .h of UUT), we've got around that. */
+
+    for(int i = 0; i < MAX_NO_HEATERS; i++)
+    {
+        EXPECT_LE(heaters[i].periodBegin, TICK_TIME);
+
+        /* Since all heaters are on 100% of the time, their periodBegins should be aligned in time*/
+        EXPECT_EQ(heaters[i].periodBegin % PWM_PERIOD, TICK_TIME % PWM_PERIOD);
+    }
+
+    allOff();
+
+    /* Tryout a few random combinations to make sure the alignment is correct. TODO: use RNG */
+    uint8_t pcts[5][4] = 
+    {
+        { 54, 89, 12, 03},
+        { 05, 78, 12, 65},
+        { 82, 02, 10, 00},
+        {100, 00, 00, 10},
+        { 12, 23, 16, 07},
+    };
+
+    /* For each combination, set the PWMs for each pin one-by-one. Check the on-periods are always
+    ** aligned back-to-back, and that the number of overlapping "stacks" from the beginning of the 
+    ** first PWM period is the minimum achievable for a particular set of PWMs */
+    for(int i = 0; i < 5; i++)
+    {
+        /* Reset relevant variables to 0 */
+        allOff();
+        int pct_count = 0;
+
+        /* Set heater PWM one-by-one */
+        for(int j = 0; j < MAX_NO_HEATERS; j++)
+        {
+            forceTick(TICK_TIME);
+            setPWMPin(j, pcts[i][j], 0);
+            pct_count += pcts[i][j];
+
+            int stack_count = 0;
+            uint32_t pb = heaters[0].periodBegin;
+            for(int k = 0; k < MAX_NO_HEATERS; k++)
+            {
+                uint32_t pct_to_period = heaters[k].pwmPercent * PWM_PERIOD / 100;
+
+                /* Everything should be set back in time */
+                EXPECT_LE(heaters[k].periodBegin, TICK_TIME);
+
+                /* Check each on-period aligns with the next heater */
+                if(k < MAX_NO_HEATERS - 1)
+                {
+                    EXPECT_EQ(heaters[k].periodBegin + pct_to_period, heaters[k+1].periodBegin);
+                }
+
+                /* If the on-period overlaps a max-period boundary, increment the stack_cout */
+                uint32_t normal_pb = heaters[k].periodBegin - pb;
+                if(normal_pb / PWM_PERIOD != (normal_pb + pct_to_period) / PWM_PERIOD)
+                {
+                    stack_count++;
+                }
+            }
+
+            /* Verify the stack count matches the percent count stack (this should be the minimum 
+            ** number of stacks to achieve the desired PWM settings ) */
+            EXPECT_EQ(stack_count, pct_count / 100) << stack_count << ", " << pct_count;
+        }
+    }
+}

--- a/unit_testing/AC/AC_tests.cpp
+++ b/unit_testing/AC/AC_tests.cpp
@@ -1,0 +1,141 @@
+/*!
+** @file   AC_tests.cpp
+** @author Luke W
+** @date   12/10/2023
+*/
+
+#include <gtest/gtest.h>
+
+#include "fake_StmGpio.h"
+#include "fake_stm32xxxx_hal.h"
+
+/* UUT */
+#include "HeatCtrl.c"
+
+/***************************************************************************************************
+** TEST FIXTURES
+***************************************************************************************************/
+
+class ACHeaterCtrl: public ::testing::Test 
+{
+    protected:
+        /*******************************************************************************************
+        ** METHODS
+        *******************************************************************************************/
+        ACHeaterCtrl()
+        {
+            /* Create a full set of heaters */
+            for(int i = 0; i < MAX_NO_HEATERS; i++) 
+            {
+                stmGpioInit(&heaterGpios[i], STM_GPIO_OUTPUT);
+                heatCtrlAdd(&heaterGpios[i], &heaterButtons[i]);
+            }
+        }
+
+        /*!
+        ** @brief Turns all the heaters on to max and checks it worked
+        */
+        void turnOnTest()
+        {
+            allOn();
+
+            for(int i = 0; i < MAX_NO_HEATERS; i++) 
+            {
+                EXPECT_EQ(getPWMPinPercent(i), 100);
+            }
+        };
+
+        /*******************************************************************************************
+        ** MEMBERS
+        *******************************************************************************************/
+        StmGpio   heaterGpios[MAX_NO_HEATERS];
+        StmGpio   heaterButtons[MAX_NO_HEATERS];
+};
+
+/***************************************************************************************************
+** TESTS
+***************************************************************************************************/
+
+TEST_F(ACHeaterCtrl, allOn) 
+{
+    /* Check everything is off by default */
+    for(int i = 0; i < MAX_NO_HEATERS; i++) 
+    {
+        EXPECT_EQ(getPWMPinPercent(i), 0);
+    }
+
+    turnOnTest();
+}
+
+TEST_F(ACHeaterCtrl, allOff) 
+{
+    turnOnTest();
+
+    allOff();
+
+    for(int i = 0; i < MAX_NO_HEATERS; i++) 
+    {
+        EXPECT_EQ(getPWMPinPercent(i), 1);
+    }
+}
+
+TEST_F(ACHeaterCtrl, turnOffPin) 
+{
+    /* Turn off pins one by one and check they turn off (and nothing else happens) */
+    for(int i = 0; i < MAX_NO_HEATERS; i++) 
+    {
+        turnOnTest();
+        turnOffPin(i);
+        for(int j = 0; j < MAX_NO_HEATERS; j++)
+        {
+            EXPECT_EQ(getPWMPinPercent(j), j == i ? 0 : 100);
+        }
+    }
+}
+
+TEST_F(ACHeaterCtrl, turnOnPin) 
+{
+    /* Turn off pins one by one and check they turn off (and nothing else happens) */
+    for(int i = 0; i < MAX_NO_HEATERS; i++) 
+    {
+        /* Note: allOff is tested in a different test, so we can probably rely on the 
+        ** outcome */
+        allOff(); 
+        turnOnPin(i);
+        for(int j = 0; j < MAX_NO_HEATERS; j++)
+        {
+            EXPECT_EQ(getPWMPinPercent(j), j == i ? 100 : 0);
+        }
+    }
+}
+
+/* Skipping turnOnPinDuration (for now) as the side-effects are difficult to evaluate without 
+** instrumentation */
+
+/* Test limited to effect of PWM as duration is difficult to assess without instrumentation */
+TEST_F(ACHeaterCtrl, setPWMPin) 
+{
+    for(int i = 0; i < MAX_NO_HEATERS; i++) 
+    {
+        /* Test the function works for a range of PWMs, JIC there is an issue e.g. with 0 or 100 */
+        for(int j = 0; j <= 100; j+= 10) 
+        {
+            setPWMPin(i, j, 0);
+            for(int k = 0; k < MAX_NO_HEATERS; k++) 
+            {
+                if(k == i)
+                {
+                    EXPECT_EQ(getPWMPinPercent(k), j) << "Heater " << k;
+                }
+                else
+                {
+                    EXPECT_EQ(getPWMPinPercent(k), 0) << "Heater " << k;
+                }
+                
+            }
+            
+        }
+        
+        setPWMPin(i, 0, 0);
+    }
+}

--- a/unit_testing/CMakeLists.txt
+++ b/unit_testing/CMakeLists.txt
@@ -42,5 +42,5 @@ gtest_discover_tests(hello_test)
 # AC tests
 add_executable(ac_test AC/AC_tests.cpp ${LIB}/Util/Src/time32.c fakes/fake_stm32xxxx_hal.cpp fakes/fake_StmGpio.c)
 target_include_directories(ac_test PRIVATE fakes ${LIB}/Util/Inc ${SRC}/AC/HeatCtrl/Inc ${SRC}/AC/HeatCtrl/Src)
-target_link_libraries(ac_test GTest::gtest_main)
+target_link_libraries(ac_test GTest::gtest_main gmock_main)
 gtest_discover_tests(ac_test)

--- a/unit_testing/CMakeLists.txt
+++ b/unit_testing/CMakeLists.txt
@@ -34,11 +34,6 @@ enable_testing()
 
 include(GoogleTest)
 
-# HelloTest
-add_executable(hello_test hello_test.cpp)
-target_link_libraries(hello_test GTest::gtest_main)
-gtest_discover_tests(hello_test)
-
 # AC tests
 add_executable(ac_test AC/AC_tests.cpp ${LIB}/Util/Src/time32.c fakes/fake_stm32xxxx_hal.cpp fakes/fake_StmGpio.c)
 target_include_directories(ac_test PRIVATE fakes ${LIB}/Util/Inc ${SRC}/AC/HeatCtrl/Inc ${SRC}/AC/HeatCtrl/Src)

--- a/unit_testing/CMakeLists.txt
+++ b/unit_testing/CMakeLists.txt
@@ -1,0 +1,46 @@
+####################################################################################################
+## Required to install gtest dependency
+####################################################################################################
+
+cmake_minimum_required(VERSION 3.14)
+project(unit_testing)
+
+# GoogleTest requires at least C++14
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+)
+
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+####################################################################################################
+## Setup source code locations / include locations
+####################################################################################################
+
+set(SRC ../STM32)
+set(LIB ../CA_Embedded_Libraries/STM32)
+
+####################################################################################################
+## List of tests to run
+###################################################################################################
+
+enable_testing()
+
+include(GoogleTest)
+
+# HelloTest
+add_executable(hello_test hello_test.cpp)
+target_link_libraries(hello_test GTest::gtest_main)
+gtest_discover_tests(hello_test)
+
+# AC tests
+add_executable(ac_test AC/AC_tests.cpp ${LIB}/Util/Src/time32.c fakes/fake_stm32xxxx_hal.cpp fakes/fake_StmGpio.c)
+target_include_directories(ac_test PRIVATE fakes ${LIB}/Util/Inc ${SRC}/AC/HeatCtrl/Inc ${SRC}/AC/HeatCtrl/Src)
+target_link_libraries(ac_test GTest::gtest_main)
+gtest_discover_tests(ac_test)

--- a/unit_testing/fakes/fake_StmGpio.c
+++ b/unit_testing/fakes/fake_StmGpio.c
@@ -1,0 +1,47 @@
+/*!
+** @file    fake_StmGpio.c
+** @author  Luke W
+** @date    12/10/2023
+**/
+
+#include "fake_StmGpio.h"
+
+/***************************************************************************************************
+** PUBLIC FUNCTIONS
+***************************************************************************************************/
+
+static void writePin(StmGpio* ctx, bool active)
+{
+    ctx->state = active ? PIN_SET : PIN_RESET;
+}
+
+static bool readPin(StmGpio *ctx)
+{
+    return (ctx->state == PIN_SET);
+}
+
+static void togglePin(struct StmGpio* ctx)
+{
+    /* Implemented like this so that other states (e.g. 2)*/
+    switch (ctx->state)
+    {
+        case PIN_RESET: ctx->state = PIN_SET;
+                        break;
+        case PIN_SET:   ctx->state = PIN_RESET;
+                        break;
+    }
+}
+
+void stmGpioInit(StmGpio *ctx, StmGpioMode_t gpioMode)
+{
+    ctx->set = writePin;
+    ctx->get = readPin;
+    ctx->toggle = togglePin;
+    ctx->mode = gpioMode;
+
+    if(gpioMode == STM_GPIO_OUTPUT) 
+    {
+        ctx->state = PIN_RESET;
+    }
+}
+

--- a/unit_testing/fakes/fake_StmGpio.h
+++ b/unit_testing/fakes/fake_StmGpio.h
@@ -1,0 +1,61 @@
+/*!
+** @file    fake_StmGpio.h
+** @author  Luke W
+** @date    12/10/2023
+**/
+
+#ifndef INC_STMGPIO_H_
+#define INC_STMGPIO_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************************************
+** DEFINES
+***************************************************************************************************/
+
+#define stmSetGpio(x, activate) { (x).set(&(x), activate); }
+#define stmGetGpio(x)           (x).get(&(x))
+#define stmToggleGpio(x)        (x).toggle(&(x))
+
+/***************************************************************************************************
+** TYPEDEFS
+***************************************************************************************************/
+
+typedef enum {
+    PIN_RESET = 0,
+    PIN_SET
+} stmGpioPinState_t;
+
+typedef enum
+{
+    STM_GPIO_OUTPUT,
+    STM_GPIO_INPUT
+    // More to come, speed etc.
+} StmGpioMode_t;
+
+typedef struct StmGpio
+{
+    void (*set)(struct StmGpio* gpio, bool activate);
+    bool (*get)(struct StmGpio* gpio);
+    void (*toggle)(struct StmGpio* gpio);
+
+    StmGpioMode_t   mode;
+    uint8_t         state;
+} StmGpio;
+
+/***************************************************************************************************
+** PUBLIC FUNCTIONS
+***************************************************************************************************/
+
+void stmGpioInit(StmGpio *ctx, StmGpioMode_t type);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INC_STMGPIO_H_ */

--- a/unit_testing/fakes/fake_stm32xxxx_hal.cpp
+++ b/unit_testing/fakes/fake_stm32xxxx_hal.cpp
@@ -1,0 +1,35 @@
+#include <chrono>
+
+#include "fake_stm32xxxx_hal.h"
+
+using namespace std::chrono;
+
+/***************************************************************************************************
+** PRIVATE MEMBERS
+***************************************************************************************************/
+
+static bool force_tick = false;
+static uint32_t next_tick = 0;
+
+/***************************************************************************************************
+** PUBLIC FUNCTIONS
+***************************************************************************************************/
+
+void forceTick(uint32_t next_val)
+{
+    force_tick = true;
+    next_tick = next_val;
+}
+
+uint32_t HAL_GetTick(void) 
+{
+    if(!force_tick)
+    {
+        return duration_cast< milliseconds >(system_clock::now().time_since_epoch()).count();
+    }
+    else 
+    {
+        force_tick = false;
+        return next_tick;
+    }
+}

--- a/unit_testing/fakes/fake_stm32xxxx_hal.cpp
+++ b/unit_testing/fakes/fake_stm32xxxx_hal.cpp
@@ -9,6 +9,7 @@ using namespace std::chrono;
 ***************************************************************************************************/
 
 static bool force_tick = false;
+static bool auto_tick = false;
 static uint32_t next_tick = 0;
 
 /***************************************************************************************************
@@ -21,15 +22,29 @@ void forceTick(uint32_t next_val)
     next_tick = next_val;
 }
 
+void autoIncTick(uint32_t next_val, bool disable)
+{
+    if(!disable)
+    {
+        auto_tick = true;
+        next_tick = next_val;
+    }
+    else
+    {
+        auto_tick = false;
+    }
+}
+
 uint32_t HAL_GetTick(void) 
 {
-    if(!force_tick)
+    if(!force_tick && !auto_tick)
     {
         return duration_cast< milliseconds >(system_clock::now().time_since_epoch()).count();
     }
     else 
     {
-        force_tick = false;
-        return next_tick;
+        /* next_tick incremented after return for auto-tick */
+        uint32_t ret_val = auto_tick ? next_tick++ : next_tick;
+        return ret_val;
     }
 }

--- a/unit_testing/fakes/fake_stm32xxxx_hal.h
+++ b/unit_testing/fakes/fake_stm32xxxx_hal.h
@@ -21,6 +21,7 @@ extern "C" {
 ***************************************************************************************************/
 
 void forceTick(uint32_t next_val);
+void autoIncTick(uint32_t next_val, bool disable=false);
 uint32_t HAL_GetTick(void);
 
 #ifdef __cplusplus

--- a/unit_testing/fakes/fake_stm32xxxx_hal.h
+++ b/unit_testing/fakes/fake_stm32xxxx_hal.h
@@ -1,0 +1,30 @@
+/*!
+** @file    fake_stm32xxxx_hal.h
+** @author  Luke W
+** @date    12/10/2023
+**/
+
+/* Prevent inclusion of real HALs, as well as re-inclusion of this one */
+#ifndef __STM32xxxx_HAL_H
+#define __STM32xxxx_HAL_H
+#define __STM32F4xx_HAL_H
+#define __STM32H7xx_HAL_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************************************
+** PUBLIC FUNCTIONS
+***************************************************************************************************/
+
+void forceTick(uint32_t next_val);
+uint32_t HAL_GetTick(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32xxxx_HAL_H */

--- a/unit_testing/hello_test.cpp
+++ b/unit_testing/hello_test.cpp
@@ -1,9 +1,0 @@
-#include <gtest/gtest.h>
-
-// Demonstrate some basic assertions.
-TEST(HelloTest, BasicAssertions) {
-  // Expect two strings not to be equal.
-  EXPECT_STRNE("hello", "world");
-  // Expect equality.
-  EXPECT_EQ(7 * 6, 42);
-}

--- a/unit_testing/hello_test.cpp
+++ b/unit_testing/hello_test.cpp
@@ -1,0 +1,9 @@
+#include <gtest/gtest.h>
+
+// Demonstrate some basic assertions.
+TEST(HelloTest, BasicAssertions) {
+  // Expect two strings not to be equal.
+  EXPECT_STRNE("hello", "world");
+  // Expect equality.
+  EXPECT_EQ(7 * 6, 42);
+}

--- a/unit_testing/unitTests.py
+++ b/unit_testing/unitTests.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+import argparse
+import subprocess
+import os
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Run unit tests')
+    # parser.add_argument('-b', '--board', help='Only run the unit tests for this board')
+    args = parser.parse_args()
+
+    subprocess.run("cmake -S . -B build", shell=True)
+    subprocess.run("cmake --build build", shell=True)
+    subprocess.run("cd build && ctest", shell=True)

--- a/unit_testing/unitTests.py
+++ b/unit_testing/unitTests.py
@@ -6,9 +6,19 @@ import os
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Run unit tests')
-    # parser.add_argument('-b', '--board', help='Only run the unit tests for this board')
+    parser.add_argument('-R', '--regex', help='Only run the unit tests matching this regex')
+    parser.add_argument('-v', '--verbose', action="store_true", help='Maximum output')
     args = parser.parse_args()
 
     subprocess.run("cmake -S . -B build", shell=True)
     subprocess.run("cmake --build build", shell=True)
-    subprocess.run("cd build && ctest", shell=True)
+
+    run_str = "cd build && ctest"
+
+    if(args.regex):
+        run_str += f" -R {args.regex}"
+
+    if(args.verbose):
+        run_str += f" --output-on-failure"
+
+    subprocess.run(run_str, shell=True)

--- a/util/dfu.py
+++ b/util/dfu.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import subprocess

--- a/util/dfu.py
+++ b/util/dfu.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+import argparse
+import subprocess
+import os
+import serial as s
+from time import sleep
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Download firmware to board.')
+    parser.add_argument('-b', '--board', help='The board to download to')
+    parser.add_argument('-p', '--port',  help='The port the board is on, if not already in DFU')
+    parser.add_argument('-r', '--reset', action="store_true", help='Reset a board in DFU mode back to normal mode')
+    parser.add_argument('-m', '--make',  action="store_true", help='Only make, don\'t download')
+    args = parser.parse_args()
+
+    if args.reset:
+        # Make a dummy upload to force the device to reset
+        subprocess.run(f"dfu-util -a 0 -s 0x08000000:leave -U temp.bin", shell=True)
+        subprocess.run(f"rm -rf temp.bin", shell=True)
+
+    elif args.board:
+        # Change to the correct directory to run make
+        owd = os.getcwd()
+
+        try:
+            os.chdir(f"STM32/{args.board}")
+            
+            # If make has an error, raise an exception
+            subprocess.run(f"make", check=True)
+
+            if args.make:
+                exit(0)
+
+            # Open the port and put the device in DFU mode
+            if args.port:
+                brd = s.Serial(port=args.port)
+                try:
+                    while(brd.is_open):
+                        brd.write("DFU\n".encode('UTF-8'))
+                        sleep(0.1)
+                except s.SerialException:
+                    pass
+                finally:
+                    brd.close()
+
+                sleep(0.5)
+
+            subprocess.run(f"dfu-util -a 0 -D build/{args.board}.bin -s 0x08000000:leave", shell=True)
+
+        finally:
+            os.chdir(owd)
+
+    else:
+        # Invalid combination of options, print help text
+        parser.print_help()


### PR DESCRIPTION
```
usage: dfu.py [-h] [-b BOARD] [-p PORT] [-r] [-m]

Download firmware to board.

options:
  -h, --help            show this help message and exit
  -b BOARD, --board BOARD
                        The board to download to
  -p PORT, --port PORT  The port the board is on, if not already in DFU
  -r, --reset           Reset a board in DFU mode back to normal mode
  -m, --make            Only make, don't download
```
Notes: this isn't something I've tested very thoroughly, just been using it and thought I'd share maybe to make other people's lives easier. It seems to work sometimes even if minicom is already open on a port.