### PR TITLE
Move static code generation test to unittest folder - Embedded

### DIFF
--- a/.github/workflows/stm32build.yml
+++ b/.github/workflows/stm32build.yml
@@ -67,7 +67,9 @@ jobs:
         python unitTests.py -D ${{ matrix.package }}
     # Run the static code analysis test.
     - name: Run static tests
-      run: STM32/CommonTests/code_generation_test.sh STM32/${{ matrix.package }}
+      run: |
+      cd unit_testing
+      ./code_generation_test.sh ${{ matrix.package }}
   build:
     needs: changes
     permissions:

--- a/.github/workflows/stm32build.yml
+++ b/.github/workflows/stm32build.yml
@@ -68,8 +68,8 @@ jobs:
     # Run the static code analysis test.
     - name: Run static tests
       run: |
-      cd unit_testing
-      ./code_generation_test.sh ${{ matrix.package }}
+        cd unit_testing
+        ./code_generation_test.sh ${{ matrix.package }}
   build:
     needs: changes
     permissions:

--- a/STM32/AC/Core/Src/main.c
+++ b/STM32/AC/Core/Src/main.c
@@ -92,9 +92,10 @@ int main(void)
 
   /* Initialize all configured peripherals */
   MX_GPIO_Init();
+  MX_ADC1_Init();
   MX_DMA_Init();
   MX_USB_DEVICE_Init();
-  MX_ADC1_Init();
+  
   MX_TIM2_Init();
   MX_WWDG_Init();
   MX_IWDG_Init();

--- a/STM32/AC/Core/Src/main.c
+++ b/STM32/AC/Core/Src/main.c
@@ -92,10 +92,9 @@ int main(void)
 
   /* Initialize all configured peripherals */
   MX_GPIO_Init();
-  MX_ADC1_Init();
   MX_DMA_Init();
   MX_USB_DEVICE_Init();
-  
+  MX_ADC1_Init();
   MX_TIM2_Init();
   MX_WWDG_Init();
   MX_IWDG_Init();

--- a/unit_testing/code_generation_test.sh
+++ b/unit_testing/code_generation_test.sh
@@ -14,14 +14,14 @@
 
 # Get the project path 
 path=$1
-if [[ ! -d "$path" ]]; then
+if [[ ! -d "../STM32/$path" ]]; then
     echo "Error: Missing project path."
     exit 1
 fi
 
 # Step 1: Ensure correct initialisation in .ioc-file.
 # Check for project .ioc file
-project_ioc=$(find $path/ -iname *.ioc)
+project_ioc=$(find ../STM32/$path/ -iname *.ioc)
 
 # Find function sort list
 function_list=$(cat $project_ioc | grep ProjectManager.functionlistsort)
@@ -45,7 +45,7 @@ for idx in $adc_idx; do
 done
 
 ## Step 2: Ensure correct initialisation in main file.
-project_main=$(find $path/Core/Src/ -iname main.c)
+project_main=$(find ../STM32/$path/Core/Src/ -iname main.c)
 
 # Find lines where MX_ADCx_Init() and MX_DMA_Init() are initialised in main.c
 adc_main_idx=$(cat $project_main | grep -n 'MX_ADC[0-9]_Init()'| cut -d : -f 1)
@@ -61,4 +61,5 @@ for idx in $adc_main_idx; do
         exit 1
     fi
 done
+echo "Static analysis passed."
 exit 0


### PR DESCRIPTION
Changes (same as embedded_private):

- [ ]  Move the static code generation test from the "STM32/CommonTests" folder to "unit_testing" folder
- [ ]  Updated related paths in script.
- [ ] Updated call in workflow file


I deliberately did not build the call of 'code_generation_tests.sh' into unitTests.py to make it clear in github actions what is what as the gtest output will drown the static test output.