### PR TITLE
Update DC input protocol

### DIFF
--- a/.github/workflows/stm32build.yml
+++ b/.github/workflows/stm32build.yml
@@ -113,7 +113,7 @@ jobs:
         env:
           VERSION_TAG: ${{ steps.tagfilter.outputs.version }}
         # Upload the .elf and .bin file under the summary tab
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.package }}
           path: |

--- a/STM32/DC/.extSettings
+++ b/STM32/DC/.extSettings
@@ -8,5 +8,5 @@ Core/Src=Core/Src/DCBoard.c;
 ../../CA_Embedded_Libraries/STM32/FLASH_readwrite/Src=../../CA_Embedded_Libraries/STM32/FLASH_readwrite/Src/FLASH_readwrite.c;../../CA_Embedded_Libraries/STM32/FLASH_readwrite/Src/HAL_otp.c;
 ../../CA_Embedded_Libraries/STM32/jumpToBootloader/Src=../../CA_Embedded_Libraries/STM32/jumpToBootloader/Src/jumpToBootloader.c;
 ../../CA_Embedded_Libraries/STM32/USBprint/Src=../../CA_Embedded_Libraries/STM32/USBprint/Src/usb_cdc_fops.c;../../CA_Embedded_Libraries/STM32/USBprint/Src/USBprint.c;
-../../CA_Embedded_Libraries/STM32/Util/Src=../../CA_Embedded_Libraries/STM32/Util/Src/CAProtocol.c;../../CA_Embedded_Libraries/STM32/Util/Src/CAProtocolStm.c;../../CA_Embedded_Libraries/STM32/Util/Src/StmGpio.c;../../CA_Embedded_Libraries/STM32/Util/Src/systeminfo.c;../../CA_Embedded_Libraries/STM32/Util/Src/time32.c;
+../../CA_Embedded_Libraries/STM32/Util/Src=../../CA_Embedded_Libraries/STM32/Util/Src/CAProtocol.c;../../CA_Embedded_Libraries/STM32/Util/Src/CAProtocolStm.c;../../CA_Embedded_Libraries/STM32/Util/Src/StmGpio.c;../../CA_Embedded_Libraries/STM32/Util/Src/systeminfo.c;../../CA_Embedded_Libraries/STM32/Util/Src/time32.c;../../CA_Embedded_Libraries/STM32/Util/Src/CAProtocolACDC.c;
 ../../CA_Embedded_Libraries/STM32/I2C/Src=../../CA_Embedded_Libraries/STM32/I2C/Src/si7051.c;

--- a/STM32/DC/Core/Src/DCBoard.c
+++ b/STM32/DC/Core/Src/DCBoard.c
@@ -91,7 +91,7 @@ static StmGpio sense24v;
 */
 static void DCInputHandler(const char* input)
 {
-    ACDCInputHandler(&caProto);
+    ACDCInputHandler(&caProto, input);
 }
 
 /*!

--- a/STM32/DC/Core/Src/DCBoard.c
+++ b/STM32/DC/Core/Src/DCBoard.c
@@ -14,6 +14,7 @@
 #include "ADCMonitor.h"
 #include "CAProtocol.h"
 #include "CAProtocolStm.h"
+#include "CAProtocolBoard.h"
 #include "time32.h"
 #include "StmGpio.h"
 #include "pcbversion.h"
@@ -39,6 +40,7 @@
 ** PRIVATE FUNCTION DECLARATIONS
 ***************************************************************************************************/
 
+static void DCInputHandler(const char* input);
 static void CAallOn(bool isOn, int duration_ms);
 static void CAportState(int port, bool state, int percent, int duration);
 static volatile uint32_t* getTimerCCR(int pinNumber);
@@ -53,7 +55,7 @@ static void handlePorts();
 
 static CAProtocolCtx caProto =
 {
-        .undefined = HALundefined,
+        .undefined = DCInputHandler,
         .printHeader = CAPrintHeader,
         .printStatus = printDcStatus,
         .jumpToBootLoader = HALJumpToBootloader,
@@ -77,12 +79,20 @@ static GPIO_TypeDef *button_ports[] = { Btn_1_GPIO_Port, Btn_2_GPIO_Port, Btn_3_
                                         Btn_4_GPIO_Port, Btn_5_GPIO_Port, Btn_6_GPIO_Port};
 static const uint16_t buttonPins[] = { Btn_1_Pin, Btn_2_Pin, Btn_3_Pin, 
                                        Btn_4_Pin, Btn_5_Pin, Btn_6_Pin };
-static StmGpio buttonGpio[ACTUATIONPORTS] = {0};
+static StmGpio buttonGpio[ACTUATIONPORTS] = {};
 static StmGpio sense24v;
 
 /***************************************************************************************************
 ** PRIVATE FUNCTION DEFINITIONS
 ***************************************************************************************************/
+
+/*!
+** @brief Call command handler for DC board
+*/
+static void DCInputHandler(const char* input)
+{
+    ACDCInputHandler(&caProto);
+}
 
 /*!
 ** @brief Verbose print of the DC board status

--- a/STM32/DC/Makefile
+++ b/STM32/DC/Makefile
@@ -51,6 +51,7 @@ C_SOURCES =  \
 ../../CA_Embedded_Libraries/STM32/USBprint/Src/USBprint.c \
 ../../CA_Embedded_Libraries/STM32/Util/Src/CAProtocol.c \
 ../../CA_Embedded_Libraries/STM32/Util/Src/CAProtocolStm.c \
+../../CA_Embedded_Libraries/STM32/Util/Src/CAProtocolBoard.c \
 ../../CA_Embedded_Libraries/STM32/Util/Src/StmGpio.c \
 ../../CA_Embedded_Libraries/STM32/Util/Src/systeminfo.c \
 ../../CA_Embedded_Libraries/STM32/Util/Src/time32.c \

--- a/STM32/DC/Makefile
+++ b/STM32/DC/Makefile
@@ -51,7 +51,7 @@ C_SOURCES =  \
 ../../CA_Embedded_Libraries/STM32/USBprint/Src/USBprint.c \
 ../../CA_Embedded_Libraries/STM32/Util/Src/CAProtocol.c \
 ../../CA_Embedded_Libraries/STM32/Util/Src/CAProtocolStm.c \
-../../CA_Embedded_Libraries/STM32/Util/Src/CAProtocolBoard.c \
+../../CA_Embedded_Libraries/STM32/Util/Src/CAProtocolACDC.c \
 ../../CA_Embedded_Libraries/STM32/Util/Src/StmGpio.c \
 ../../CA_Embedded_Libraries/STM32/Util/Src/systeminfo.c \
 ../../CA_Embedded_Libraries/STM32/Util/Src/time32.c \

--- a/unit_testing/DC/CMakeLists.txt
+++ b/unit_testing/DC/CMakeLists.txt
@@ -9,6 +9,12 @@ project(unit_testing)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Set timestamp policy to avoid warning (default value)
+if(POLICY CMP0135)
+	cmake_policy(SET CMP0135 NEW)
+	set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
+endif()
+
 include(FetchContent)
 FetchContent_Declare(
   googletest

--- a/unit_testing/DC/DC_tests.cpp
+++ b/unit_testing/DC/DC_tests.cpp
@@ -1,5 +1,5 @@
 /*!
-** @file   AC_tests.cpp
+** @file   DC_tests.cpp
 ** @author Luke W
 ** @date   12/10/2023
 */
@@ -16,6 +16,7 @@
 #include "ADCmonitor.c"
 #include "CAProtocol.c"
 #include "CAProtocolStm.c"
+#include "CAProtocolBoard.c"
 
 /* UUT */
 #include "DCBoard.c"


### PR DESCRIPTION
 - The inputCAProtocol now redirects AC / DC specific handler code to the `caProto.undefined()` function which in turn calls the inputhandler defined in the PR below.
- Update of CA_Embedded_Libraries can be found in this [PR](https://github.com/copenhagenatomics/CA_Embedded_Libraries/actions/runs/13073231940/job/36479235207)
 - Update of the build script as the version we were using of the upload-artifact action has been deprecated.
