### PR TITLE
Revert Flash Memory Layout 

### DIFF
--- a/STM32/ACTenChannel/stm32f401ccux_flash.ld
+++ b/STM32/ACTenChannel/stm32f401ccux_flash.ld
@@ -62,11 +62,7 @@ _Min_Stack_Size = 0x400; /* required amount of stack */
 MEMORY
 {
 RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 64K
-FLASHISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K
-FLASHCAL (r)  : ORIGIN = 0x08004000, LENGTH = 16K
-FLASHCAL2 (r) : ORIGIN = 0x08008000, LENGTH = 16K
-FLASHCAL3 (r) : ORIGIN = 0x0800C000, LENGTH = 16K
-FLASH (rx)     : ORIGIN = 0x08010000, LENGTH = 192K
+FLASH (rx)     : ORIGIN = 0x08000000, LENGTH = 256K
 }
 
 /* Main program area. Area may not be used for user data storage */
@@ -82,25 +78,7 @@ SECTIONS
     . = ALIGN(4);
     KEEP(*(.isr_vector)) /* Startup code */
     . = ALIGN(4);
-  } >FLASHISR
-
-  .calData (NOLOAD) :
-  {
-    KEEP(*(.calData))
-    . = . + 0x4000;
-  } > FLASHCAL
-
-  .calData2 (NOLOAD) :
-  {
-    KEEP(*(.calData2))
-    . = . + 0x4000;
-  } > FLASHCAL2
-
-  .calData3 (NOLOAD) :
-  {
-    KEEP(*(.calData3))
-    . = . + 0x4000;
-  } > FLASHCAL3
+  } >FLASH
 
   /* The program code and other data goes into FLASH */
   .text :

--- a/STM32/Pressure/STM32F401CCUx_FLASH.ld
+++ b/STM32/Pressure/STM32F401CCUx_FLASH.ld
@@ -63,9 +63,8 @@ _Min_Stack_Size = 0x400; /* required amount of stack */
 MEMORY
 {
   RAM    (xrw)    : ORIGIN = 0x20000000,   LENGTH = 64K
-  FLASHISR (rx)   : ORIGIN = 0x08000000,   LENGTH = 16K
-  FLASHCAL (r)    : ORIGIN = 0x08004000,   LENGTH = 16K
-  FLASH    (rx)   : ORIGIN = 0x08008000,   LENGTH = 224K
+  FLASH    (rx)   : ORIGIN = 0x08000000,   LENGTH = 128K
+  FLASHCAL (r)    : ORIGIN = 0x08020000,   LENGTH = 128K
 }
 
 _ProgramMemoryStart = ORIGIN(FLASH);
@@ -82,13 +81,7 @@ SECTIONS
     . = ALIGN(4);
     KEEP(*(.isr_vector)) /* Startup code */
     . = ALIGN(4);
-  } >FLASHISR
-
-  .calData (NOLOAD) :
-  {
-    KEEP(*(.calData))
-    . = . + 0x4000;
-  } > FLASHCAL
+  } >FLASH
 
   /* The program code and other data goes into FLASH */
   .text :


### PR DESCRIPTION
* Changes to linker scripts to move calibration area to the end of the flash.

Note: Current cannot fit in the flash if the CAL is moved to the end. But LoopControl always sends the calibration when it is turned on, so it is not an immediate problem