### PR TITLE
Bugfix/dc 3.1 misreads

### DIFF
--- a/.github/workflows/stm32build.yml
+++ b/.github/workflows/stm32build.yml
@@ -2,11 +2,11 @@ name: C/C++ stm32 build for the open-source embedded software
 
 on:
   push:
-    branches: [ 'main' ]
-    paths: ['STM32/**', '.github/workflows/stm32build.yml']
+    branches: [ 'patch/dc-3.1' ]
+    paths: ['STM32/DC/**', '.github/workflows/stm32build.yml']
   pull_request:
-    branches: [ 'main' ]
-    paths: ['STM32/**', '.github/workflows/stm32build.yml']
+    branches: [ 'patch/dc-3.1' ]
+    paths: ['STM32/DC/**', '.github/workflows/stm32build.yml']
 
 jobs:
   # JOB to run change detection
@@ -123,8 +123,8 @@ jobs:
             STM32/${{ matrix.package }}/build/${{ matrix.package }}.bin
       - uses: copenhagenatomics/mono_release_on_push_action@master
         id: release-on-push-2
-        # tag only pushes to the main branch
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        # tag only pushes to the patch/dc-3.1 branch
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/patch/dc-3.1' }}
         with:
           bump_version_scheme: minor
           use_github_release_notes: true
@@ -146,14 +146,14 @@ jobs:
             echo "breaking=$(eval "./util/pcbversion.py STM32/${{ matrix.package }}/pcbversion breaking both")" >> $GITHUB_OUTPUT
           fi 
       - name: Rename build files for Github release
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }} # upload only pushes to the main branch
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/patch/dc-3.1' }} # upload only pushes to the patch/dc-3.1 branch
         # Rename .elf and .bin files to include release tag and pcb version in the Github release
         run: |
           RELEASENAME=${{ steps.release-on-push-2.outputs.tag_name }}-PCBv${{ steps.pcbversion.outputs.latest }}
           cp STM32/${{ matrix.package }}/build/${{ matrix.package }}.elf ${RELEASENAME}.elf
           cp STM32/${{ matrix.package }}/build/${{ matrix.package }}.bin ${RELEASENAME}.bin
       - name: Release
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }} # upload only pushes to the main branch
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/patch/dc-3.1' }} # upload only pushes to the patch/dc-3.1 branch
         uses: softprops/action-gh-release@v0.1.15
         with:
           files: |
@@ -176,7 +176,7 @@ jobs:
           AZURE_BLOB_QUERYSTRING : ${{ secrets.AZURE_BLOB_QUERYSTRING }}
           MODULE_NAME : ${{ matrix.package }}
       - name: Manage PCB Versioning
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }} # File only updated on merge into main (not on pull-request)
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/patch/dc-3.1' }} # File only updated on merge into patch/dc-3.1 (not on pull-request)
         run: python release_mgmt/managePcbVersions.py -c $(echo "${{ steps.pcbversion.outputs.latest }}" | sed 's/[a-zA-Z]//g') -b $(echo "${{ steps.pcbversion.outputs.breaking }}" | sed 's/[a-zA-Z]//g') -fw ${{ steps.tagfilter.outputs.version }} -m ${{ matrix.package }}
         env :
           AZURE_BLOB_QUERYSTRING : ${{ secrets.AZURE_BLOB_QUERYSTRING }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ build/
 githash.h
 /**/settings.json
 
-# Compiled python files
+# Python files
 *.pyc
+.venv

--- a/STM32/DC/Core/Src/DCBoard.c
+++ b/STM32/DC/Core/Src/DCBoard.c
@@ -428,7 +428,7 @@ static void handlePorts() {
 
 void DCBoardInit(ADC_HandleTypeDef *_hadc, WWDG_HandleTypeDef* hwwdg)
 {
-    boardSetup(DC_Board, (pcbVersion){BREAKING_MAJOR, BREAKING_MINOR});
+    boardSetup(DC_Board, (pcbVersion){BREAKING_MAJOR, BREAKING_MINOR}, DC_BOARD_No_Error_Msk);
     /* Always allow for DFU also if programmed on non-matching board or PCB version. */
     initCAProtocol(&caProto, usbRx);
 


### PR DESCRIPTION
### Bug Description

A bug occurs with a low frequency where the following text will be printed in the log (~1-2 times per hour, e.g. once every 10000 commands)
```
[uploader33] Unexpected board response 'MISREAD: p1\r'
```

### Analysis

The root cause of the error has not been located yet. It is very sensitive to the timing of commands, and also the configuration of the stack. Disabling optimisations appears to remove the bug. These things make debugging difficult and time consuming. 

The bug has been traced to occur during the processing of the "getArgs" function. It occurs regardless of whether the function is interrupted or not (during testing the function has been bracketed by __disable_irqs()). Given that getArgs is essentially a wrapper around strtok, it seems likely that the bug is something to do with the strtok function. strtok is an opaque library function.

### Mitigation

The bug should be considered active until the root cause is identified and understood. However removing the strtok function and replacing it with a similar behaviour either fixes or masks the bug, reducing unnecessary warning messages for other teams.

Library pull here: https://github.com/copenhagenatomics/CA_Embedded_Libraries/pull/89