### PR TITLE
AC Board MISREADs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ build/
 githash.h
 /**/settings.json
 
-# Compiled python files
+# Python files
 *.pyc
+.venv

--- a/STM32/AC/Core/Src/ACBoard.c
+++ b/STM32/AC/Core/Src/ACBoard.c
@@ -441,7 +441,7 @@ static void updateBoardStatus()
 void ACBoardInit(ADC_HandleTypeDef* hadc)
 {
     // Pin out has changed from PCB V6.4 - older versions need other software.
-    boardSetup(AC_Board, (pcbVersion){BREAKING_MAJOR, BREAKING_MINOR});
+    boardSetup(AC_Board, (pcbVersion){BREAKING_MAJOR, BREAKING_MINOR}, AC_BOARD_No_Error_Msk);
 
     // Always allow for DFU also if programmed on non-matching board or PCB version.
     initCAProtocol(&caProto, usbRx);


### PR DESCRIPTION
See also: https://github.com/copenhagenatomics/CA_Embedded/pull/232

### Bug Description

A bug occurs with a low frequency where the following text will be printed in the log (~1-2 times per hour, e.g. once every 10000 commands)
```
[uploader33] Unexpected board response 'MISREAD: p1\r'
```

### Analysis

The root cause of the error has not been located yet. It is very sensitive to the timing of commands, and also the configuration of the stack. Disabling optimisations appears to remove the bug. These things make debugging difficult and time consuming. 

The bug has been traced to occur during the processing of the "getArgs" function. It occurs regardless of whether the function is interrupted or not (during testing the function has been bracketed by __disable_irqs()). Given that getArgs is essentially a wrapper around strtok, it seems likely that the bug is something to do with the strtok function. strtok is an opaque library function.

### Mitigation

The bug should be considered active until the root cause is identified and understood. However removing the strtok function and replacing it with a similar behaviour either fixes or masks the bug, reducing unnecessary warning messages for other teams.

Library pull here: https://github.com/copenhagenatomics/CA_Embedded_Libraries/pull/89