### PR TITLE
Updated AC V6.4 to the latest libraries

### DIFF
--- a/STM32/AC/Core/Src/ACBoard.c
+++ b/STM32/AC/Core/Src/ACBoard.c
@@ -19,6 +19,7 @@
 #include "CAProtocolStm.h"
 #include "StmGpio.h"
 #include "ACBoard.h"
+#include "CAProtocolACDC.h"
 
 
 
@@ -68,6 +69,12 @@ static StmGpio fanCtrl;
 static double heatSinkTemperature = 0; // Heat Sink temperature
 static bool isFanForceOn = false;
 
+static ACDCProtocolCtx acProto =
+{
+        .allOn = CAallOn,
+        .portState = CAportState
+};
+
 static CAProtocolCtx caProto =
 {
         .undefined = userInput,
@@ -78,9 +85,7 @@ static CAProtocolCtx caProto =
         .calibrationRW = NULL,
         .logging = NULL,
         .otpRead = CAotpRead,
-        .otpWrite = NULL,
-        .allOn = CAallOn,
-        .portState = CAportState,
+        .otpWrite = NULL
 };
 
 /***************************************************************************************************
@@ -119,7 +124,7 @@ static void userInput(const char *input)
     }
     else 
     {
-        HALundefined(input);
+        ACDCInputHandler(&acProto, input);
     }
 }
 
@@ -371,7 +376,7 @@ static void updateBoardStatus()
 void ACBoardInit(ADC_HandleTypeDef* hadc, WWDG_HandleTypeDef* hwwdg)
 {
     // Pin out has changed from PCB V6.4 - older versions need other software.
-    boardSetup(AC_Board, (pcbVersion){6, 4});
+    boardSetup(AC_Board, (pcbVersion){6, 4}, AC_BOARD_No_Error_Msk);
 
     // Always allow for DFU also if programmed on non-matching board or PCB version.
     initCAProtocol(&caProto, usbRx);

--- a/STM32/AC/Makefile
+++ b/STM32/AC/Makefile
@@ -27,7 +27,7 @@ TARGET = AC
 # building variables
 ######################################
 # debug build?
-DEBUG = 1
+DEBUG = 0
 # optimization
 OPT = -O2
 
@@ -52,6 +52,7 @@ C_SOURCES =  \
 ../../CA_Embedded_Libraries/STM32/USBprint/Src/USBprint.c \
 ../../CA_Embedded_Libraries/STM32/Util/Src/CAProtocol.c \
 ../../CA_Embedded_Libraries/STM32/Util/Src/CAProtocolStm.c \
+../../CA_Embedded_Libraries/STM32/Util/Src/CAProtocolACDC.c \
 ../../CA_Embedded_Libraries/STM32/Util/Src/StmGpio.c \
 ../../CA_Embedded_Libraries/STM32/Util/Src/systeminfo.c \
 ../../CA_Embedded_Libraries/STM32/Util/Src/time32.c \

--- a/unit_testing/AC/AC_tests.cpp
+++ b/unit_testing/AC/AC_tests.cpp
@@ -17,6 +17,7 @@
 #include "ADCmonitor.c"
 #include "CAProtocol.c"
 #include "CAProtocolStm.c"
+#include "CAProtocolACDC.c"
 
 /* UUT */
 #include "ACBoard.c"
@@ -307,7 +308,7 @@ TEST_F(ACBoard, InvalidCommands)
     writeAcMessage("p4 on 80%\n");
     EXPECT_FLUSH_USB(Contains("MISREAD: p4 on -1"));
     writeAcMessage("all on\n");
-    EXPECT_FLUSH_USB(Contains("MISREAD: all on -1"));
+    EXPECT_FLUSH_USB(Contains("MISREAD: all on"));
 }
 
 TEST_F(ACBoard, UsbTimeout)

--- a/unit_testing/AC/CMakeLists.txt
+++ b/unit_testing/AC/CMakeLists.txt
@@ -43,7 +43,7 @@ include(GoogleTest)
 
 # AC tests
 add_executable(heatCtrl_test heatCtrl_tests.cpp ${LIB}/Util/Src/time32.c ${UT_FAKES}/fake_stm32xxxx_hal.cpp ${UT_FAKES}/fake_StmGpio.cpp)
-target_include_directories(heatCtrl_test PRIVATE ${UT_FAKES} ${LIB}/Util/Inc ${SRC}/AC/HeatCtrl/Inc ${SRC}/AC/HeatCtrl/Src ${DRIV}/Inc ${DRIV}/../CMSIS/Device/ST/STM32F4xx/Include)
+target_include_directories(heatCtrl_test PRIVATE ${UT_FAKES} ${LIB}/Util/Inc ${SRC}/AC/Core/Inc ${SRC}/AC/HeatCtrl/Inc ${SRC}/AC/HeatCtrl/Src ${DRIV}/Inc ${DRIV}/../CMSIS/Device/ST/STM32F4xx/Include)
 target_link_libraries(heatCtrl_test GTest::gtest_main gmock_main)
 gtest_discover_tests(heatCtrl_test)
 


### PR DESCRIPTION
### Primary Changes

* Minor changes to LightController to force update library
* Within library, usb_cdc_fops.c:usb_cdc_transmit has a bug fixed where is was possible for the USB interrupt to become permanently disabled
* Added CAProtocolACDC for compatibility with latest libraries

### Testing

- [x] unit tests
- [ ] Benchtop tests