### PR TITLE
Saltleak USB interrupt bug

### DIFF
--- a/STM32/SaltLeak/Core/Src/saltleakLoop.c
+++ b/STM32/SaltLeak/Core/Src/saltleakLoop.c
@@ -190,7 +190,8 @@ void saltleakInit(ADC_HandleTypeDef *hadc1, TIM_HandleTypeDef *htim5, WWDG_Handl
      ** the readings will just be bogus */
     ADCMonitorInit(hadc1, ADCBuffer, sizeof(ADCBuffer) / sizeof(int16_t));
 
-    if (-1 == boardSetup(SaltLeak, (pcbVersion){BREAKING_MAJOR, BREAKING_MINOR})) {
+    if (-1 == boardSetup(SaltLeak, (pcbVersion){BREAKING_MAJOR, BREAKING_MINOR},
+        SALTLEAK_NO_ERROR_Msk)) {
         return;
     }
 

--- a/unit_testing/SaltLeak/CMakeLists.txt
+++ b/unit_testing/SaltLeak/CMakeLists.txt
@@ -29,7 +29,7 @@ FetchContent_MakeAvailable(googletest)
 ## Setup source code locations / include locations
 ####################################################################################################
 
-set(SRC ../../STM32)
+set(SRC ../../STM32/SaltLeak)
 set(LIB ../../CA_Embedded_Libraries/STM32)
 set(INC_LIB ${LIB}/ADCMonitor/Inc ${LIB}/circularBuffer/Inc ${LIB}/Filtering/Inc 
             ${LIB}/FLASH_readwrite/Inc ${LIB}/I2C/Inc ${LIB}/jumpToBootloader/Inc 
@@ -38,7 +38,7 @@ set(INC_LIB ${LIB}/ADCMonitor/Inc ${LIB}/circularBuffer/Inc ${LIB}/Filtering/Inc
 set(UT_LIB ../../CA_Embedded_Libraries/unit_testing)
 set(UT_FAKES ${UT_LIB}/fakes)
 set(UT_STUBS ${UT_LIB}/stubs)
-set(DRIV ${LIB}/Drivers/STM32F4xx_HAL_Driver)
+set(DRIV ${SRC}/Drivers/STM32F4xx_HAL_Driver)
 
 ####################################################################################################
 ## List of tests to run
@@ -50,7 +50,7 @@ include(GoogleTest)
 
 # SaltLeak tests
 add_executable(saltleak_test saltleak_tests.cpp ${UT_STUBS}/stub_jumpToBootloader.cpp ${LIB}/Util/Src/systeminfo.c ${UT_FAKES}/fake_USBprint.cpp ${LIB}/Util/Src/time32.c ${UT_FAKES}/fake_stm32xxxx_hal.cpp ${UT_FAKES}/fake_StmGpio.cpp ${UT_FAKES}/fake_HAL_otp.cpp ${UT_LIB}/Util/serialStatus_tests.cpp)
-target_include_directories(saltleak_test PRIVATE ${UT_FAKES} ${UT_STUBS} ${SRC}/SaltLeak/Core/Src ${SRC}/SaltLeak/Core/Inc ${LIB}/ADCMonitor/Src ${LIB}/Util/Src ${INC_LIB} ${DRIV}/Inc ${DRIV}/../CMSIS/Device/ST/STM32F4xx/Include ${UT_LIB}/Util)
+target_include_directories(saltleak_test PRIVATE ${UT_FAKES} ${UT_STUBS} ${SRC}/Core/Src ${SRC}/Core/Inc ${LIB}/ADCMonitor/Src ${LIB}/Util/Src ${INC_LIB} ${DRIV}/Inc ${DRIV}/../CMSIS/Device/ST/STM32F4xx/Include ${UT_LIB}/Util)
 target_link_libraries(saltleak_test GTest::gtest_main gmock_main)
 target_compile_definitions(saltleak_test PUBLIC UNIT_TESTING)
 gtest_discover_tests(saltleak_test)


### PR DESCRIPTION
### Primary Changes

* Minor changes to SaltLeak to force update library
* Within library, usb_cdc_fops.c:usb_cdc_transmit has a bug fixed where is was possible for the USB interrupt to become permanently disabled

### Testing

- [x] unit tests
- [x] Benchtop tests